### PR TITLE
Makes INV/GETDATA messages able to carry multiple item

### DIFF
--- a/hyper-lib/Cargo.toml
+++ b/hyper-lib/Cargo.toml
@@ -11,6 +11,7 @@ Supporting library for hyperion: a discrete time network event simulator for Bit
 [dependencies]
 # FIXME: Move this into a feature
 graphrs = "0.9.0"
+itertools = "0.13.0"
 log = "0.4.20"
 priority-queue = "2.0.3"
 rand = "0.8.5"

--- a/hyper-lib/src/node.rs
+++ b/hyper-lib/src/node.rs
@@ -1,5 +1,6 @@
 use std::collections::{hash_map::Entry, HashMap, HashSet};
 
+use itertools::Itertools;
 use rand::rngs::StdRng;
 use rand_distr::{Distribution, Exp};
 
@@ -48,7 +49,7 @@ impl PoissonTimer {
 pub struct Peer {
     /// Set of transactions pending to be announced. This is populated when a new announcement event
     /// is scheduled, and consumed once the event takes place
-    scheduled_announcements: HashSet<TxId>,
+    to_be_announced: Vec<TxId>,
     /// Transactions already known by this peer, this is populated either when a peer announced a transaction
     /// to us, or when we send a transaction to them
     known_transactions: HashSet<TxId>,
@@ -57,7 +58,7 @@ pub struct Peer {
 impl Peer {
     pub fn new() -> Self {
         Self {
-            scheduled_announcements: HashSet::new(),
+            to_be_announced: Vec::new(),
             known_transactions: HashSet::new(),
         }
     }
@@ -70,16 +71,12 @@ impl Peer {
         self.known_transactions.insert(txid);
     }
 
-    fn has_announcement_scheduled(&mut self, txid: &TxId) -> bool {
-        self.scheduled_announcements.contains(txid)
+    pub fn add_tx_to_be_announced(&mut self, txid: TxId) {
+        self.to_be_announced.push(txid)
     }
 
-    fn schedule_announcement(&mut self, txid: TxId) {
-        self.scheduled_announcements.insert(txid);
-    }
-
-    fn remove_scheduled_announcement(&mut self, txid: &TxId) {
-        self.scheduled_announcements.remove(txid);
+    pub fn drain_txs_to_be_announced(&mut self) -> Vec<TxId> {
+        self.to_be_announced.drain(..).collect()
     }
 }
 
@@ -106,7 +103,7 @@ pub struct Node {
     /// Set of transactions that have already been requested (but not yet received)
     requested_transactions: HashSet<TxId>,
     /// Set of transactions which request has been delayed (see [Node::add_request])
-    delayed_requests: HashMap<TxId, NodeId>,
+    delayed_requests: HashMap<NodeId, Vec<TxId>>,
     /// Set of transaction already known by the node
     known_transactions: HashSet<TxId>,
     /// Poisson timer shared by all inbound peers. Used to decide when to announce transactions to them
@@ -172,6 +169,12 @@ impl Node {
             poisson_timer.next_interval = current_time + poisson_timer.sample(&mut self.rng);
         }
         poisson_timer.next_interval
+    }
+
+    fn get_peer(&self, peer_id: &NodeId) -> Option<&Peer> {
+        self.out_peers
+            .get(peer_id)
+            .or_else(|| self.in_peers.get(peer_id))
     }
 
     fn get_peer_mut(&mut self, peer_id: &NodeId) -> Option<&mut Peer> {
@@ -247,14 +250,26 @@ impl Node {
         self.known_transactions.insert(txid);
     }
 
+    fn filter_known_and_requested_transactions<'a, I>(
+        &'a self,
+        iter: I,
+    ) -> impl Iterator<Item = I::Item> + 'a
+    where
+        I: Iterator<Item = &'a TxId> + 'a,
+    {
+        iter.filter(move |txid| {
+            !self.knows_transaction(txid) && !self.requested_transactions.contains(txid)
+        })
+    }
+
     pub fn get_statistics(&self) -> &NodeStatistics {
         &self.node_statistics
     }
 
     /// Schedules the announcement of a given transaction to all our peers, based on when the next announcement interval will be.
-    /// Inbound peers use a shared poisson timer with expected value of [INBOUND_INVENTORY_BROADCAST_INTERVAL] seconds (simulated),
+    /// Inbound peers use a shared Poisson timer with expected value of [INBOUND_INVENTORY_BROADCAST_INTERVAL] seconds,
     /// while outbound have a unique one with expected value of [OUTBOUND_INVENTORY_BROADCAST_INTERVAL] seconds.
-    /// Returns a collection of the scheduled events, including re-sampling of the time intervals
+    /// Returns a collection of the scheduled events
     pub fn broadcast_tx(&mut self, txid: TxId, current_time: u64) -> Vec<(Event, u64)> {
         self.add_known_transaction(txid);
         let mut events = Vec::new();
@@ -262,141 +277,169 @@ impl Node {
         for peer_id in self.out_peers.keys().cloned().collect::<Vec<_>>() {
             // We are initializing the transaction's originator interval sampling here. This is because
             // we don't want to start sampling until we have something to send to our peers. Otherwise we
-            // would create useless events just for sampling. Notice this works since samples from a
-            // Poisson process is memoryless (past events do not affect future events)
+            // would create useless events just for sampling. Notice this works since a Poisson process is memoryless
+            // hence past events do not affect future ones
             let next_interval = self.get_next_announcement_time(current_time, Some(peer_id));
             debug_log!(
                 current_time,
                 self.node_id,
-                "Scheduling inv to peer {peer_id}"
+                "Scheduling inv to peer {peer_id} for time {next_interval}"
             );
             // Schedule the announcement to go off on the next trickle for the given peer
-            events.push((self.schedule_announcement(peer_id, txid), next_interval));
+            self.get_peer_mut(&peer_id)
+                .unwrap()
+                .add_tx_to_be_announced(txid);
+            events.push((
+                Event::process_scheduled_announcement(self.node_id, peer_id),
+                next_interval,
+            ));
         }
 
         // For inbounds we use a shared interval
         let next_interval = self.get_next_announcement_time(current_time, None);
+        debug_log!(
+            current_time,
+            self.node_id,
+            "Scheduling inv to inbound peers for time {next_interval}"
+        );
         for peer_id in self.in_peers.keys().cloned().collect::<Vec<_>>() {
-            events.push((self.schedule_announcement(peer_id, txid), next_interval));
+            self.get_peer_mut(&peer_id)
+                .unwrap()
+                .add_tx_to_be_announced(txid);
+            events.push((
+                Event::process_scheduled_announcement(self.node_id, peer_id),
+                next_interval,
+            ));
         }
 
         events
-    }
-
-    /// Creates an scheduled announcement for a given transaction to a given peer.
-    /// TODO: Notice this creates an announcement **per transaction**, while INVs can actually
-    /// hold many transaction on the same message. This will need to be updated when we simulate
-    /// broadcasting multiple transactions
-    fn schedule_announcement(&mut self, peer_id: NodeId, txid: TxId) -> Event {
-        let peer = self.get_peer_mut(&peer_id).unwrap();
-        assert!(
-            !peer.has_announcement_scheduled(&txid),
-            "Node {peer_id} already has an announcement scheduled for transaction (txid: {txid:x})",
-        );
-        peer.schedule_announcement(txid);
-        Event::process_delayed_announcement(self.node_id, peer_id, txid)
     }
 
     /// Processes a previously scheduled transaction announcement to a given peer, returning an event (and the time at which it should be processed) if successful
     pub fn process_scheduled_announcement(
         &mut self,
         peer_id: NodeId,
-        txid: TxId,
         current_time: u64,
     ) -> Option<(Event, u64)> {
-        self.get_peer_mut(&peer_id)
-            .unwrap()
-            .remove_scheduled_announcement(&txid);
-        self.send_message_to(NetworkMessage::INV(txid), peer_id, current_time)
+        // We assume all transactions pending to be announced fit in a single INV message. This is a simplification.
+        // However, an INV message fits up to 50000 entries, so it should be enough for out simulation purposes.
+        // https://github.com/bitcoin/bitcoin/blob/20ccb30b7af1c30cece2b0579ba88aa101583f07/src/net_processing.cpp#L87-L88
+        let peer = self.get_peer_mut(&peer_id).unwrap();
+        // Filter all transactions that the peer already knows (because they have announced them to us already)
+        let to_be_announced = peer
+            .drain_txs_to_be_announced()
+            .into_iter()
+            .filter(|txid| !peer.knows_transaction(txid))
+            .collect::<Vec<TxId>>();
+
+        if to_be_announced.is_empty() {
+            return None;
+        } else {
+            self.send_message_to(NetworkMessage::INV(to_be_announced), peer_id, current_time)
+        }
     }
 
-    /// Adds the request of a given transaction to a given node to our trackers. If the node is inbounds, this will generate
+    /// Adds the request of a set of transactions to a given node to our trackers. If the node is inbounds, this will generate
     /// a delayed request, and return an event to be processed later in time. If the node is outbounds, the request will be generated
-    /// straightaway. No request will be generated if we already know the transaction
+    /// straightaway. No request will be generated if we already know all provided transactions
     fn add_request(
         &mut self,
-        txid: TxId,
+        txids: Vec<TxId>,
         peer_id: NodeId,
         request_time: u64,
     ) -> Option<(Event, u64)> {
+        let to_be_requested = self
+            .filter_known_and_requested_transactions(txids.iter())
+            .map(|x| *x)
+            .collect::<Vec<_>>();
+        if to_be_requested.is_empty() {
+            debug_log!(
+                request_time,
+                self.node_id,
+                "Already known transactions (txids: [{:x}]), not requesting them to peer_id: {peer_id}",
+                txids.iter().format(", ")
+            );
+            return None;
+        }
+
         // Transactions are only requested from a single peer (assuming honest behavior)
         // Inbound peers are de-prioritized. If an outbound peer announces a transaction
         // and an inbound peer request is in delayed stage, the inbounds will be dropped and
         // the outbound will be processed
-        if !self.knows_transaction(&txid) && !self.requested_transactions.contains(&txid) {
-            if self.is_inbounds(&peer_id) {
-                if let Entry::Vacant(e) = self.delayed_requests.entry(txid) {
-                    e.insert(peer_id);
-                    debug_log!(request_time, self.node_id, "Delaying getdata for transaction request (txid: {txid:x}) to peer {peer_id}");
-                    return Some((
-                        Event::process_delayed_request(self.node_id, txid),
-                        request_time + NONPREF_PEER_TX_DELAY * SECS_TO_NANOS,
-                    ));
-                } else {
-                    debug_log!(request_time, self.node_id, "Another delayed getdata for transaction (txid: {txid:x}) has already been scheduled, not requesting to peer_id: {peer_id}");
-                }
-            } else {
-                debug_log!(
-                    request_time,
-                    self.node_id,
-                    "Sending getdata to peer {peer_id}",
-                );
-                self.requested_transactions.insert(txid);
-                self.delayed_requests.remove(&txid);
-                return Some((
-                    Event::receive_message_from(
-                        self.node_id,
-                        peer_id,
-                        NetworkMessage::GETDATA(txid),
-                    ),
-                    request_time,
-                ));
+        if self.is_inbounds(&peer_id) {
+            debug_log!(
+                request_time,
+                self.node_id,
+                "Delaying getdata for transactions (txids: [{:x}]) to peer {peer_id}",
+                to_be_requested.iter().format(", ")
+            );
+            for txid in to_be_requested.iter() {
+                match self.delayed_requests.entry(peer_id) {
+                    Entry::Occupied(mut e) => {
+                        e.get_mut().push(*txid);
+                    }
+                    Entry::Vacant(e) => {
+                        e.insert(vec![*txid]);
+                    }
+                };
             }
+            Some((
+                Event::process_delayed_request(self.node_id, peer_id),
+                request_time + NONPREF_PEER_TX_DELAY * SECS_TO_NANOS,
+            ))
         } else {
             debug_log!(
                 request_time,
                 self.node_id,
-                "Already known transaction (txid: {txid:x}), not requesting to peer_id: {peer_id}",
+                "Sending getdata for transactions (txids: [{:x}]) to peer {peer_id}",
+                to_be_requested.iter().format(", ")
             );
+            self.requested_transactions.extend(to_be_requested.iter());
+            Some((
+                Event::receive_message_from(
+                    self.node_id,
+                    peer_id,
+                    NetworkMessage::GETDATA(to_be_requested),
+                ),
+                request_time,
+            ))
         }
-
-        None
     }
 
-    /// Processes a delayed request for a given transaction. If the transaction has not been requested by anyone else, the delayed
-    /// request will be moved to a normal request and an event will be generated. If an outbound peer have requested this transaction
-    /// during our delay, this will simply be dropped.
+    /// Processes a delayed request for a given inbound peer. If any transaction is still pending to be requested, the delayed request
+    /// will be processed and an event will be generated. If all transactions have been already requested to outbound peers
+    /// during our delay, the request will simply be dropped.
     /// Notice that we do not queue requests (because the nodes is the simulator are well behaved)
     pub fn process_delayed_request(
         &mut self,
-        txid: TxId,
+        peer_id: NodeId,
         request_time: u64,
     ) -> Option<(Event, u64)> {
-        if !self.knows_transaction(&txid) && !self.requested_transactions.contains(&txid) {
-            if let Some(peer_id) = self.delayed_requests.remove(&txid) {
-                self.requested_transactions.insert(txid);
-
-                let msg = NetworkMessage::GETDATA(txid);
-                self.node_statistics.add_sent(msg, true);
-                return Some((
-                    Event::receive_message_from(self.node_id, peer_id, msg),
-                    request_time,
-                ));
-            } else {
-                panic!("Trying to process a delayed request that was never added to the collection (txid: {}).", txid);
-            }
-        } else {
-            // A delayed request was triggered but it has already been covered by a non-delayed one
-            self.delayed_requests.remove(&txid);
+        let pending = self.delayed_requests.remove(&peer_id).unwrap_or_else(|| {
+            panic!("Trying to process an non-existing delayed request for peer_id: {peer_id}")
+        });
+        let to_be_requested = self
+            .filter_known_and_requested_transactions(pending.iter())
+            .map(|x| *x)
+            .collect::<Vec<_>>();
+        if to_be_requested.is_empty() {
+            debug_log!(
+                request_time,
+                self.node_id,
+                "A non-delayed request for transactions (txids: [{:x}]), has already been processed. Not requesting them to peer_id: {peer_id}",
+                pending.iter().format(", ")
+            );
+            return None;
         }
 
-        None
-    }
+        self.requested_transactions.extend(to_be_requested.iter());
+        let msg = NetworkMessage::GETDATA(to_be_requested);
+        self.node_statistics.add_sent(&msg, true);
 
-    /// Removes a request for a given transaction from our trackers
-    fn remove_request(&mut self, txid: &TxId) {
-        assert!(!self.delayed_requests.contains_key(txid));
-        assert!(self.requested_transactions.remove(txid));
+        Some((
+            Event::receive_message_from(self.node_id, peer_id, msg),
+            request_time,
+        ))
     }
 
     /// Tries so send a message (of a given type) to a given peer, creating the corresponding receive message event if successful.
@@ -407,60 +450,63 @@ impl Node {
         peer_id: NodeId,
         request_time: u64,
     ) -> Option<(Event, u64)> {
-        let we_know_tx = self.knows_transaction(msg.inner());
-        let mut message = None;
+        let message: Option<(Event, u64)>;
 
-        if let Some(peer) = self.get_peer_mut(&peer_id) {
+        if let Some(peer) = self.get_peer(&peer_id) {
             match msg {
-                NetworkMessage::INV(txid) => {
-                    assert!(we_know_tx, "Trying to announce a transaction we should't know about (txid: {txid:x}) to a peer (peer_id: {peer_id})");
-                    // Don't send the transaction to a peer that has already announced it to us
-                    if peer.knows_transaction(&txid) {
-                        debug_log!(
-                            request_time,
-                            self.node_id,
-                            "Node {peer_id} has already announced transaction {txid:x} to us, not announcing it back",
-                        );
-                        return None;
+                NetworkMessage::INV(ref txids) => {
+                    assert!(!txids.is_empty(), "Trying to send out an empty transaction announcement to a peer (peer_id: {peer_id})");
+                    for txid in txids.iter() {
+                        assert!(self.knows_transaction(txid), "Trying to announce a transaction we should't know about (txid: {txid:x}) to a peer (peer_id: {peer_id})");
+                        assert!(!peer.knows_transaction(txid), "Trying to announce a transaction (txid: {txid:x}) to a peer that already knows about it (peer_id: {peer_id})");
                     }
-                    debug_log!(
-                        request_time,
-                        self.node_id,
-                        "Sending {msg} to peer {peer_id}"
-                    );
+
                     message = Some((
                         Event::receive_message_from(self.node_id, peer_id, msg),
                         request_time,
                     ));
                 }
-                NetworkMessage::GETDATA(txid) => {
-                    assert!(!we_know_tx, "Trying to request a transaction we already know about (txid: {txid:x}) from a peer (peer_id: {peer_id})");
-                    assert!(peer.knows_transaction(&txid), "Trying to request a transaction (txid: {txid:x}) from a peer that shouldn't know about it (peer_id: {peer_id})");
-                    message = self.add_request(txid, peer_id, request_time);
+                NetworkMessage::GETDATA(txids) => {
+                    assert!(!txids.is_empty(), "Trying to send out an empty transaction request to a peer (peer_id: {peer_id})");
+                    for txid in txids.iter() {
+                        assert!(!self.knows_transaction(txid), "Trying to request a transaction we already know about (txid: {txid:x}) from a peer (peer_id: {peer_id})");
+                        assert!(peer.knows_transaction(txid), "Trying to request a transaction (txid: {txid:x}) from a peer that shouldn't know about it (peer_id: {peer_id})");
+                    }
+
+                    message = self.add_request(txids, peer_id, request_time);
                 }
                 NetworkMessage::TX(txid) => {
-                    assert!(we_know_tx, "Trying to send a transaction we should't know about (txid: {txid:x}) to a peer (peer_id: {peer_id})");
+                    assert!(self.knows_transaction(&txid), "Trying to send a transaction we should't know about (txid: {txid:x}) to a peer (peer_id: {peer_id})");
                     assert!(!peer.knows_transaction(&txid), "Trying to send a transaction (txid: {txid:x}) to a peer that already should know about it (peer_id: {peer_id})");
-                    peer.add_known_transaction(txid);
-                    debug_log!(
-                        request_time,
-                        self.node_id,
-                        "Sending {msg} to peer {peer_id}"
-                    );
+                    self.get_peer_mut(&peer_id)
+                        .unwrap()
+                        .add_known_transaction(txid);
+
                     message = Some((
                         Event::receive_message_from(self.node_id, peer_id, msg),
                         request_time,
                     ));
                 }
             }
+        } else {
+            panic!(
+                "Trying to send a message to a node we are not connected to (node_id: {peer_id})"
+            )
         }
 
         // Only update the "sent" node stats if we are creating a "receive from"
         // message event for a peer
         if let Some((event, _)) = &message {
-            if event.is_receive_message() {
-                self.node_statistics
-                    .add_sent(msg, self.is_inbounds(&peer_id));
+            if let Some(msg) = event.get_message() {
+                if event.is_receive_message() {
+                    debug_log!(
+                        request_time,
+                        self.node_id,
+                        "Sending {msg} to peer {peer_id}"
+                    );
+                    self.node_statistics
+                        .add_sent(msg, self.is_inbounds(&peer_id));
+                }
             }
         }
 
@@ -475,34 +521,36 @@ impl Node {
         peer_id: NodeId,
         request_time: u64,
     ) -> Vec<(Event, u64)> {
+        assert!(
+            self.get_peer(&peer_id).is_some(),
+            "Received an message from a node we are not connected to (node_id: {peer_id})"
+        );
         debug_log!(
             request_time,
             self.node_id,
             "Received {msg} from peer {peer_id}"
         );
-        let we_know_tx = self.knows_transaction(msg.inner());
-        let mut events = Vec::new();
-        self.node_statistics
-            .add_received(msg, self.is_inbounds(&peer_id));
 
-        if let Some(peer) = self.get_peer_mut(&peer_id) {
-            match msg {
-                NetworkMessage::INV(txid) => {
-                    peer.add_known_transaction(txid);
+        self.node_statistics
+            .add_received(&msg, self.is_inbounds(&peer_id));
+
+        // We cannot hold a reference of peer here since we call mutable methods in the same context.
+        // Maybe we can work around this by passing a reference to the peer instead of the node id
+        // and getting another reference down the line
+        match msg {
+            NetworkMessage::INV(txids) => {
+                assert!(
+                    !txids.is_empty(),
+                    "Received an empty transaction announcement from peer (peer_id: {peer_id})"
+                );
+                let mut to_be_requested = Vec::new();
+                for txid in txids.into_iter() {
+                    self.get_peer_mut(&peer_id)
+                        .unwrap()
+                        .add_known_transaction(txid);
                     // We only request transactions that we don't know about
-                    if !we_know_tx {
-                        debug_log!(
-                            request_time,
-                            self.node_id,
-                            "Transaction unknown. Scheduling getdata to peer {peer_id}",
-                        );
-                        if let Some(event) = self.send_message_to(
-                            NetworkMessage::GETDATA(txid),
-                            peer_id,
-                            request_time,
-                        ) {
-                            events.push(event);
-                        }
+                    if !self.knows_transaction(&txid) {
+                        to_be_requested.push(txid)
                     } else {
                         debug_log!(
                             request_time,
@@ -511,24 +559,32 @@ impl Node {
                         );
                     }
                 }
-                NetworkMessage::GETDATA(txid) => {
-                    assert!(we_know_tx, "Received transaction request for a transaction we don't know of (txid: {txid:x}) from a peer (peer_id: {peer_id})");
-                    assert!(!peer.knows_transaction(&txid), "Received a transaction request (txid: {txid:x}) from a peer that should already know about it (peer_id {peer_id})");
-                    if let Some(event) =
-                        self.send_message_to(NetworkMessage::TX(txid), peer_id, request_time)
-                    {
-                        events.push(event);
-                    }
-                }
-                NetworkMessage::TX(txid) => {
-                    assert!(!we_know_tx, "Received a transaction we already know of (txid: {txid:x}) from a peer (peer_id: {peer_id})");
-                    assert!(peer.knows_transaction(&txid), "Received a transaction (txid: {txid:x}) from a node that shouldn't know about it (peer_id {peer_id})");
-                    self.remove_request(&txid);
-                    events.extend(self.broadcast_tx(txid, request_time));
+                if !to_be_requested.is_empty() {
+                    self.send_message_to(
+                        NetworkMessage::GETDATA(to_be_requested),
+                        peer_id,
+                        request_time,
+                    )
+                    .map_or(Vec::new(), |x| vec![x])
+                } else {
+                    // If all entries have been filtered out there is no point calling [self::send_message_to]
+                    Vec::new()
                 }
             }
+            NetworkMessage::GETDATA(txids) => {
+                txids.iter().map(|txid| {
+                        assert!(self.knows_transaction(txid), "Received transaction request for a transaction we don't know of (txid: {txid:x}) from a peer (peer_id: {peer_id})");
+                        assert!(!self.get_peer(&peer_id).unwrap().knows_transaction(txid), "Received a transaction request (txid: {txid:x}) from a peer that should already know about it (peer_id {peer_id})");
+                        // Send tx cannot return None
+                        self.send_message_to(NetworkMessage::TX(*txid), peer_id, request_time).unwrap()
+                    }).collect::<Vec<_>>()
+            }
+            NetworkMessage::TX(txid) => {
+                assert!(!self.knows_transaction(&txid), "Received a transaction we already know of (txid: {txid:x}) from a peer (peer_id: {peer_id})");
+                assert!(self.get_peer(&peer_id).unwrap().knows_transaction(&txid), "Received a transaction (txid: {txid:x}) from a node that shouldn't know about it (peer_id {peer_id})");
+                self.requested_transactions.remove(&txid);
+                self.broadcast_tx(txid, request_time)
+            }
         }
-
-        events
     }
 }

--- a/hyper-lib/src/node.rs
+++ b/hyper-lib/src/node.rs
@@ -272,18 +272,10 @@ impl Node {
             );
             // Schedule the announcement to go off on the next trickle for the given peer
             events.push((self.schedule_announcement(peer_id, txid), next_interval));
-            events.push((
-                Event::sample_new_interval(self.node_id, Some(peer_id)),
-                next_interval,
-            ));
         }
 
         // For inbounds we use a shared interval
         let next_interval = self.get_next_announcement_time(current_time, None);
-        events.push((
-            Event::sample_new_interval(self.node_id, None),
-            next_interval,
-        ));
         for peer_id in self.in_peers.keys().cloned().collect::<Vec<_>>() {
             events.push((self.schedule_announcement(peer_id, txid), next_interval));
         }

--- a/hyper-lib/src/simulator.rs
+++ b/hyper-lib/src/simulator.rs
@@ -17,10 +17,10 @@ static NET_DELAY_MEAN: f64 = 0.01 * SECS_TO_NANOS as f64; // 10ms
 pub enum Event {
     /// The destination (0) receives a new message (2) from given source (1)
     ReceiveMessageFrom(NodeId, NodeId, NetworkMessage),
-    /// A given node (0) processes an scheduled announcements (2) to a given peer (1)
-    ProcessScheduledAnnouncement(NodeId, NodeId, TxId),
+    /// A given node (0) processes an scheduled announcements to a given peer (1)
+    ProcessScheduledAnnouncement(NodeId, NodeId),
     /// A given node (0) processed a delayed request of a give transaction (1)
-    ProcessDelayedRequest(NodeId, TxId),
+    ProcessDelayedRequest(NodeId, NodeId),
 }
 
 impl Event {
@@ -28,12 +28,12 @@ impl Event {
         Event::ReceiveMessageFrom(src, dst, msg)
     }
 
-    pub fn process_delayed_announcement(src: NodeId, dst: NodeId, txid: TxId) -> Self {
-        Event::ProcessScheduledAnnouncement(src, dst, txid)
+    pub fn process_scheduled_announcement(src: NodeId, dst: NodeId) -> Self {
+        Event::ProcessScheduledAnnouncement(src, dst)
     }
 
-    pub fn process_delayed_request(src: NodeId, txid: TxId) -> Self {
-        Event::ProcessDelayedRequest(src, txid)
+    pub fn process_delayed_request(src: NodeId, dst: NodeId) -> Self {
+        Event::ProcessDelayedRequest(src, dst)
     }
 
     pub fn is_receive_message(&self) -> bool {
@@ -42,6 +42,13 @@ impl Event {
 
     pub fn is_delayed_request(&self) -> bool {
         matches!(self, Event::ProcessDelayedRequest(..))
+    }
+
+    pub fn get_message(&self) -> Option<&NetworkMessage> {
+        match self {
+            Event::ReceiveMessageFrom(_, _, m) => Some(m),
+            _ => None,
+        }
     }
 }
 

--- a/hyper-lib/src/simulator.rs
+++ b/hyper-lib/src/simulator.rs
@@ -15,8 +15,6 @@ static NET_DELAY_MEAN: f64 = 0.01 * SECS_TO_NANOS as f64; // 10ms
 /// An enumeration of all the events that can be created in a simulation
 #[derive(Clone, Hash, Eq, PartialEq)]
 pub enum Event {
-    /// Sample a new time interval for a given node (or for all inbounds if node id is provided)
-    SampleNewInterval(NodeId, Option<NodeId>),
     /// The destination (0) receives a new message (2) from given source (1)
     ReceiveMessageFrom(NodeId, NodeId, NetworkMessage),
     /// A given node (0) processes an scheduled announcements (2) to a given peer (1)
@@ -26,10 +24,6 @@ pub enum Event {
 }
 
 impl Event {
-    pub fn sample_new_interval(target: NodeId, peer_id: Option<NodeId>) -> Self {
-        Event::SampleNewInterval(target, peer_id)
-    }
-
     pub fn receive_message_from(src: NodeId, dst: NodeId, msg: NetworkMessage) -> Self {
         Event::ReceiveMessageFrom(src, dst, msg)
     }

--- a/hyper-lib/src/statistics.rs
+++ b/hyper-lib/src/statistics.rs
@@ -60,7 +60,7 @@ impl NodeStatistics {
     }
 
     /// Adds a sent message to the statistics
-    pub fn add_sent(&mut self, msg: NetworkMessage, to_inbound: bool) {
+    pub fn add_sent(&mut self, msg: &NetworkMessage, to_inbound: bool) {
         let (to, bytes) = if to_inbound {
             (&mut self.inv.to_inbounds, &mut self.bytes.to_inbounds)
         } else {
@@ -71,11 +71,11 @@ impl NodeStatistics {
             NetworkMessage::GETDATA(_) => *to += 1,
             NetworkMessage::TX(_) => *to += 1,
         }
-        *bytes += msg.get_size();
+        *bytes += msg.get_size() as u32;
     }
 
     /// Adds a receive message to the statistics
-    pub fn add_received(&mut self, msg: NetworkMessage, from_inbound: bool) {
+    pub fn add_received(&mut self, msg: &NetworkMessage, from_inbound: bool) {
         let (from, bytes) = if from_inbound {
             (&mut self.inv.from_inbounds, &mut self.bytes.from_inbounds)
         } else {
@@ -86,7 +86,7 @@ impl NodeStatistics {
             NetworkMessage::GETDATA(_) => *from += 1,
             NetworkMessage::TX(_) => *from += 1,
         }
-        *bytes += msg.get_size();
+        *bytes += msg.get_size() as u32;
     }
 
     pub fn get_sent_count(&self) -> u32 {

--- a/hyperion/src/main.rs
+++ b/hyperion/src/main.rs
@@ -39,13 +39,6 @@ fn main() -> anyhow::Result<()> {
     // Process events until the queue is empty
     while let Some((event, time)) = simulator.get_next_event() {
         match event {
-            Event::SampleNewInterval(target, peer_id) => {
-                simulator
-                    .network
-                    .get_node_mut(target)
-                    .unwrap()
-                    .get_next_announcement_time(time, peer_id);
-            }
             Event::ReceiveMessageFrom(src, dst, msg) => {
                 if msg.is_tx() && percentile_time == 0 {
                     nodes_reached += 1;

--- a/hyperion/src/main.rs
+++ b/hyperion/src/main.rs
@@ -55,12 +55,12 @@ fn main() -> anyhow::Result<()> {
                     simulator.add_event(future_event, future_time);
                 }
             }
-            Event::ProcessScheduledAnnouncement(src, dst, txid) => {
+            Event::ProcessScheduledAnnouncement(src, dst) => {
                 if let Some((scheduled_event, t)) = simulator
                     .network
                     .get_node_mut(src)
                     .unwrap()
-                    .process_scheduled_announcement(dst, txid, time)
+                    .process_scheduled_announcement(dst, time)
                 {
                     simulator.add_event(scheduled_event, t);
                 }


### PR DESCRIPTION
Makes message sizes more accurate and allows multiple items in announcements/requests.

Scheduled announcements/delayed requests are now triggered on a per-peer basis instead of per transaction basis (which is the actual proper approach). INVs are, however, assumed to be able to hold any amount of transactions needed to be exchanged. This is an oversimplification, but it should be good enough for the simulator.

Also gets rid of the `SampleNewInterval` event, which was unnecessary. The node was already resampling at the proper time without the simulator having to handle the action as a scheduled event.

FIxes #1 