### PR TITLE
Adds Erlay functionality 

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -1,0 +1,31 @@
+name: Build, lint and test
+
+on: workflow_call
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    name: Check Code with stable output
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@1.76.0
+      - name: Install Clippy
+        run: rustup component add clippy
+      - name: Install Rustfmt
+        run: rustup component add rustfmt
+      - name: run check
+        run: make check
+
+  build:
+    name: Build and test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - name: cargo build
+        run: cargo build --release --all-features
+      - name: cargo test
+        run: cargo test --all-features --all-targets --benches

--- a/hyper-lib/src/indexedmap.rs
+++ b/hyper-lib/src/indexedmap.rs
@@ -1,0 +1,93 @@
+use std::collections::hash_map::Keys;
+use std::collections::HashMap;
+use std::hash::Hash;
+
+#[derive(Clone)]
+pub struct IndexedMap<K, V> {
+    map: HashMap<K, V>,
+    // Consider storing references. I didn't do it because that means carrying the lifetime
+    // over all the objects including this map
+    // If we are on with adding lifetimes, making this a Cycle iterator may also be an option
+    order: Vec<K>,
+    next_index: usize,
+}
+
+impl<K, V> IndexedMap<K, V>
+where
+    K: Hash + Eq + Copy,
+{
+    pub fn new() -> Self {
+        Self {
+            map: HashMap::new(),
+            order: Vec::new(),
+            next_index: 0,
+        }
+    }
+
+    pub fn inner(&self) -> &HashMap<K, V> {
+        &self.map
+    }
+
+    pub fn insert(&mut self, key: K, value: V) -> Option<V> {
+        self.order.push(key);
+        self.map.insert(key, value)
+    }
+
+    pub fn get(&self, key: &K) -> Option<&V> {
+        self.map.get(key)
+    }
+
+    pub fn get_mut(&mut self, key: &K) -> Option<&mut V> {
+        self.map.get_mut(key)
+    }
+
+    pub fn contains_key(&self, key: &K) -> bool {
+        self.map.contains_key(key)
+    }
+
+    pub fn keys(&self) -> Keys<'_, K, V> {
+        self.map.keys()
+    }
+
+    pub fn len(&self) -> usize {
+        self.map.len()
+    }
+
+    pub fn get_next(&mut self) -> (K, &mut V) {
+        if self.map.is_empty() {
+            panic!("Called get_next on a empty IndexedMap")
+        }
+
+        // If we've reached the end of the map, circle back
+        let next_index = self.next_index % self.map.len();
+        let key = self
+            .order
+            .get(next_index)
+            .expect("Tried to fetch an non-existing item from an IndexedMap");
+        self.next_index = next_index + 1;
+
+        (*key, self.map.get_mut(key).unwrap())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_get_next() {
+        let mut map = IndexedMap::new();
+
+        // Check that we get the index of the last added element
+        for i in 0..10 {
+            map.insert(i, i * 2);
+            assert_eq!(map.get_next().0, i);
+        }
+
+        // Check that, if we iterate over the added elements
+        // the returned key cycles over once the last element is reached
+        for i in 0..3 * map.len() {
+            assert_eq!(map.get_next().0, i % 10);
+        }
+    }
+}

--- a/hyper-lib/src/lib.rs
+++ b/hyper-lib/src/lib.rs
@@ -5,6 +5,8 @@ pub mod simulator;
 pub mod statistics;
 pub mod txreconciliation;
 
+mod indexedmap;
+
 pub type TxId = u32;
 
 pub const MAX_OUTBOUND_CONNECTIONS: usize = 8;

--- a/hyper-lib/src/lib.rs
+++ b/hyper-lib/src/lib.rs
@@ -3,6 +3,7 @@ pub mod network;
 pub mod node;
 pub mod simulator;
 pub mod statistics;
+pub mod txreconciliation;
 
 pub type TxId = u32;
 

--- a/hyper-lib/src/lib.rs
+++ b/hyper-lib/src/lib.rs
@@ -11,3 +11,13 @@ pub type TxId = u32;
 
 pub const MAX_OUTBOUND_CONNECTIONS: usize = 8;
 static SECS_TO_NANOS: u64 = 1_000_000_000;
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use rand::{self, RngCore};
+
+    pub(crate) fn get_random_txid() -> TxId {
+        rand::thread_rng().next_u32()
+    }
+}

--- a/hyper-lib/src/network.rs
+++ b/hyper-lib/src/network.rs
@@ -10,7 +10,7 @@ use rand::distributions::{Distribution, Uniform};
 use rand::rngs::StdRng;
 
 /// Defines the collection of network messages that can be exchanged between peers
-#[derive(Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash, Debug)]
 pub enum NetworkMessage {
     INV(Vec<TxId>),
     GETDATA(Vec<TxId>),

--- a/hyper-lib/src/network.rs
+++ b/hyper-lib/src/network.rs
@@ -9,8 +9,6 @@ use itertools::Itertools;
 use rand::distributions::{Distribution, Uniform};
 use rand::rngs::StdRng;
 
-const NET_MESSAGE_HEADER_SIZE: usize = 4 + 12 + 4 + 4;
-
 /// Defines the collection of network messages that can be exchanged between peers
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub enum NetworkMessage {
@@ -258,6 +256,10 @@ impl Network {
 
     pub fn get_nodes(&self) -> &Vec<Node> {
         &self.nodes
+    }
+
+    pub fn get_nodes_mut(&mut self) -> &mut Vec<Node> {
+        &mut self.nodes
     }
 
     fn get_reachable_nodes(&self) -> &[Node] {

--- a/hyper-lib/src/node.rs
+++ b/hyper-lib/src/node.rs
@@ -333,7 +333,7 @@ impl Node {
             .collect::<Vec<TxId>>();
 
         if to_be_announced.is_empty() {
-            return None;
+            None
         } else {
             self.send_message_to(NetworkMessage::INV(to_be_announced), peer_id, current_time)
         }
@@ -350,7 +350,7 @@ impl Node {
     ) -> Option<(Event, u64)> {
         let to_be_requested = self
             .filter_known_and_requested_transactions(txids.iter())
-            .map(|x| *x)
+            .copied()
             .collect::<Vec<_>>();
         if to_be_requested.is_empty() {
             debug_log!(
@@ -420,7 +420,7 @@ impl Node {
         });
         let to_be_requested = self
             .filter_known_and_requested_transactions(pending.iter())
-            .map(|x| *x)
+            .copied()
             .collect::<Vec<_>>();
         if to_be_requested.is_empty() {
             debug_log!(

--- a/hyper-lib/src/node.rs
+++ b/hyper-lib/src/node.rs
@@ -469,6 +469,16 @@ impl Node {
         peer_id: NodeId,
         request_time: u64,
     ) -> Option<(Event, u64)> {
+        if msg.is_erlay() {
+            assert!(
+                self.is_erlay,
+                "Trying to send an Erlay message to a peer (node_id: {peer_id}), but we do not support Erlay"
+            );
+            assert!(
+                self.get_peer(&peer_id).unwrap().is_erlay(),
+                "Trying to send an Erlay message to a peer (node_id: {peer_id}), but the it hasn't signaled Erlay support"
+            );
+        }
         let message: Option<(Event, u64)>;
 
         if let Some(peer) = self.get_peer(&peer_id) {
@@ -506,6 +516,8 @@ impl Node {
                         request_time,
                     ));
                 }
+                // FIXME: Erlay messages go here
+                _ => todo!(),
             }
         } else {
             panic!(
@@ -544,6 +556,16 @@ impl Node {
             self.get_peer(&peer_id).is_some(),
             "Received an message from a node we are not connected to (node_id: {peer_id})"
         );
+        if msg.is_erlay() {
+            assert!(
+                self.is_erlay,
+                "Received an Erlay message from a peer (node_id: {peer_id}), but we do not support Erlay"
+            );
+            assert!(
+                self.get_peer(&peer_id).unwrap().is_erlay(),
+                "Received an Erlay message from a peer (node_id: {peer_id}), but the it hasn't signaled Erlay support"
+            );
+        }
         debug_log!(
             request_time,
             self.node_id,
@@ -604,6 +626,8 @@ impl Node {
                 self.requested_transactions.remove(&txid);
                 self.broadcast_tx(txid, request_time)
             }
+            // FIXME: Erlay messages go here
+            _ => todo!(),
         }
     }
 }

--- a/hyper-lib/src/simulator.rs
+++ b/hyper-lib/src/simulator.rs
@@ -40,10 +40,6 @@ impl Event {
         matches!(self, Event::ReceiveMessageFrom(..))
     }
 
-    pub fn is_delayed_request(&self) -> bool {
-        matches!(self, Event::ProcessDelayedRequest(..))
-    }
-
     pub fn get_message(&self) -> Option<&NetworkMessage> {
         match self {
             Event::ReceiveMessageFrom(_, _, m) => Some(m),

--- a/hyper-lib/src/simulator.rs
+++ b/hyper-lib/src/simulator.rs
@@ -63,6 +63,7 @@ impl Simulator {
     pub fn new(
         reachable_count: usize,
         unreachable_count: usize,
+        is_erlay: bool,
         seed: Option<u64>,
         network_latency: bool,
     ) -> Self {
@@ -75,7 +76,7 @@ impl Simulator {
             s
         };
         let mut rng: StdRng = StdRng::seed_from_u64(seed);
-        let network = Network::new(reachable_count, unreachable_count, &mut rng);
+        let network = Network::new(reachable_count, unreachable_count, is_erlay, &mut rng);
 
         // Create a network latency function for sent/received messages. This is in the order of
         // nanoseconds, using a LogNormal distribution with expected value NET_LATENCY_MEAN, and

--- a/hyper-lib/src/simulator.rs
+++ b/hyper-lib/src/simulator.rs
@@ -13,7 +13,7 @@ use crate::{TxId, SECS_TO_NANOS};
 static NET_LATENCY_MEAN: f64 = 0.01 * SECS_TO_NANOS as f64; // 10ms
 
 /// An enumeration of all the events that can be created in a simulation
-#[derive(Clone, Hash, Eq, PartialEq)]
+#[derive(Clone, Hash, Eq, PartialEq, Debug)]
 pub enum Event {
     /// The destination (0) receives a new message (2) from given source (1)
     ReceiveMessageFrom(NodeId, NodeId, NetworkMessage),

--- a/hyper-lib/src/txreconciliation.rs
+++ b/hyper-lib/src/txreconciliation.rs
@@ -1,3 +1,7 @@
+use std::collections::HashSet;
+
+use itertools::Itertools;
+
 use crate::TxId;
 
 pub type ShortID = u32;
@@ -9,12 +13,12 @@ pub type ShortID = u32;
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct Sketch {
     tx_set: Vec<ShortID>,
-    q: usize,
+    d: usize,
 }
 
 impl Sketch {
-    pub fn new(tx_set: Vec<TxId>, q: usize) -> Self {
-        Self { tx_set, q }
+    pub fn new(tx_set: Vec<TxId>, d: usize) -> Self {
+        Self { tx_set, d }
     }
 
     pub fn get_tx_set(&self) -> &Vec<TxId> {
@@ -22,33 +26,94 @@ impl Sketch {
     }
 
     pub fn get_size(&self) -> usize {
-        self.q
+        self.d
     }
 }
 
 #[derive(Clone)]
 pub struct TxReconciliationState {
     /// Whether this peer is the reconciliation initiator or we are
-    pub is_initiator: bool,
+    is_initiator: bool,
+    /// Whether we are currently reconciling with this peer or not
+    is_reconciling: bool,
     /// Set of transactions to be reconciled with this peer (using Erlay).
     /// Normally, ShortIDs would be 32 bits as opposed to 256-bit TxIds. However, we are already simplifying
     /// TxIds to be 32-bit, so here it'd be a one-to-one mapping
-    to_be_reconciled: Vec<ShortID>,
+    recon_set: HashSet<ShortID>,
+    // Set of transactions to be added to the reconciliation set on the next trickle. These are still unrequestable for
+    // privacy reasons (to prevent transaction proving), transactions became available once they would have been announced
+    // via fanout (on the next trickle).
+    delayed_set: HashSet<ShortID>,
 }
 
 impl TxReconciliationState {
     pub fn new(is_initiator: bool) -> Self {
         Self {
             is_initiator,
-            to_be_reconciled: Vec::new(),
+            is_reconciling: false,
+            recon_set: HashSet::new(),
+            delayed_set: HashSet::new(),
         }
+    }
+
+    pub fn clear(&mut self) -> HashSet<ShortID> {
+        self.is_reconciling = false;
+        self.recon_set.drain().collect()
     }
 
     pub fn is_initiator(&self) -> bool {
         self.is_initiator
     }
 
-    pub fn add_tx_to_be_reconciled(&mut self, txid: TxId) {
-        self.to_be_reconciled.push(txid)
+    pub fn add_tx(&mut self, txid: TxId) -> bool {
+        self.delayed_set.insert(txid)
+    }
+
+    /// Removes a transaction from the reconciliation set. This may happen if a peer has announced a transaction that we
+    /// were planing to reconcile with them. Notice that, if this happens after creating a snapshot, the reconciliation will
+    /// result in one additional item on the exchanged INV (belonging to this transaction). This is equivalent to two INVs crossing,
+    /// and AFAIK, there's nothing we can do about it
+    pub fn remove_tx(&mut self, txid: &TxId) {
+        self.delayed_set.remove(txid);
+        self.recon_set.remove(txid);
+    }
+
+    // Make delayed transactions available for reconciliation
+    pub fn make_delayed_available(&mut self) {
+        self.recon_set.extend(self.delayed_set.drain());
+    }
+
+    pub fn set_reconciling(&mut self) {
+        self.is_reconciling = true;
+    }
+
+    pub fn is_reconciling(&self) -> bool {
+        self.is_reconciling
+    }
+
+    pub fn get_recon_set(&self) -> &HashSet<ShortID> {
+        &self.recon_set
+    }
+
+    pub fn compute_sketch(&mut self, their_txs: Vec<TxId>) -> Sketch {
+        // Given predicting q is hard in a short simulation, we exchange the collection of transactions to be reconciled
+        // between the two parties. Here, q is computed as the difference between the two collections (local and remote)
+        // And a figurative Sketch is created
+        let local_set = self.get_recon_set();
+        let remote_set = HashSet::from_iter(their_txs);
+        let q = local_set.symmetric_difference(&remote_set).count();
+        // TODO: Scale q if required so the predicted difference is not always 100% accurate
+        Sketch::new(local_set.iter().copied().collect_vec(), q)
+    }
+
+    pub fn compute_sketch_diff(&self, sketch: Sketch) -> (Vec<u32>, Vec<u32>) {
+        let local_set: HashSet<&u32> = HashSet::from_iter(self.get_recon_set());
+        let remote_set = HashSet::from_iter(sketch.get_tx_set());
+
+        // We care about what we are missing, that's what we send to our peer
+        let our_diff: Vec<u32> = remote_set.difference(&local_set).map(|x| **x).collect_vec();
+        let their_diff = local_set.difference(&remote_set).map(|x| **x).collect_vec();
+
+        (our_diff, their_diff)
     }
 }

--- a/hyper-lib/src/txreconciliation.rs
+++ b/hyper-lib/src/txreconciliation.rs
@@ -10,7 +10,7 @@ pub type ShortID = u32;
 // The only thing we need to know is what transactions a node knows, and what is the size of the difference between that
 // and the set of transaction its peer knows. The difference can be computed on the fly, but it is stored here so we can keep
 // track of the size of the message for statistics.
-#[derive(Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash, Debug)]
 pub struct Sketch {
     tx_set: Vec<ShortID>,
     d: usize,

--- a/hyper-lib/src/txreconciliation.rs
+++ b/hyper-lib/src/txreconciliation.rs
@@ -1,0 +1,54 @@
+use crate::TxId;
+
+pub type ShortID = u32;
+
+// This is a hack. A sketch is really built using Minisketch. However, this is not necessary for the simulator.
+// The only thing we need to know is what transactions a node knows, and what is the size of the difference between that
+// and the set of transaction its peer knows. The difference can be computed on the fly, but it is stored here so we can keep
+// track of the size of the message for statistics.
+#[derive(Clone, PartialEq, Eq, Hash)]
+pub struct Sketch {
+    tx_set: Vec<ShortID>,
+    q: usize,
+}
+
+impl Sketch {
+    pub fn new(tx_set: Vec<TxId>, q: usize) -> Self {
+        Self { tx_set, q }
+    }
+
+    pub fn get_tx_set(&self) -> &Vec<TxId> {
+        &self.tx_set
+    }
+
+    pub fn get_size(&self) -> usize {
+        self.q
+    }
+}
+
+#[derive(Clone)]
+pub struct TxReconciliationState {
+    /// Whether this peer is the reconciliation initiator or we are
+    pub is_initiator: bool,
+    /// Set of transactions to be reconciled with this peer (using Erlay).
+    /// Normally, ShortIDs would be 32 bits as opposed to 256-bit TxIds. However, we are already simplifying
+    /// TxIds to be 32-bit, so here it'd be a one-to-one mapping
+    to_be_reconciled: Vec<ShortID>,
+}
+
+impl TxReconciliationState {
+    pub fn new(is_initiator: bool) -> Self {
+        Self {
+            is_initiator,
+            to_be_reconciled: Vec::new(),
+        }
+    }
+
+    pub fn is_initiator(&self) -> bool {
+        self.is_initiator
+    }
+
+    pub fn add_tx_to_be_reconciled(&mut self, txid: TxId) {
+        self.to_be_reconciled.push(txid)
+    }
+}

--- a/hyper-lib/src/txreconciliation.rs
+++ b/hyper-lib/src/txreconciliation.rs
@@ -123,6 +123,12 @@ mod test {
     use super::*;
     use crate::test::get_random_txid;
 
+    impl TxReconciliationState {
+        pub(crate) fn get_delayed_set(&self) -> &HashSet<ShortID> {
+            &self.delayed_set
+        }
+    }
+
     #[test]
     fn test_recon_state() {
         let mut tx_recon_state = TxReconciliationState::new(true);

--- a/hyperion/src/cli.rs
+++ b/hyperion/src/cli.rs
@@ -28,6 +28,9 @@ pub struct Cli {
     /// Target percentile of node the transaction needs to reach. Use to measure propagation times
     #[clap(long, short, default_value_t = TARGET_PERCENTILE, value_parser = clap::value_parser!(u16).range(1..101))]
     pub percentile_target: u16,
+    /// Whether nodes in the simulation support Erlay or not (all of them for now, this is likely to change)
+    #[clap(long)]
+    pub erlay: bool,
     /// Seed to run random activity generator deterministically
     #[clap(long, short)]
     pub seed: Option<u64>,

--- a/hyperion/src/main.rs
+++ b/hyperion/src/main.rs
@@ -17,7 +17,13 @@ fn main() -> anyhow::Result<()> {
         .unwrap();
 
     let node_count = cli.reachable + cli.unreachable;
-    let mut simulator = Simulator::new(cli.reachable, cli.unreachable, cli.seed, !cli.no_latency);
+    let mut simulator = Simulator::new(
+        cli.reachable,
+        cli.unreachable,
+        cli.erlay,
+        cli.seed,
+        !cli.no_latency,
+    );
 
     // Pick a (source) node to broadcast the target transaction from.
     let txid = simulator.get_random_txid();


### PR DESCRIPTION
Adds Erlay functionality to the simulator. With this, simulations can now be run for the usual `INV->GETDATA->TX` flow (fanout from now on) and for the Erlay flow. If Erlay is selected, all nodes are set as so, so no mix simulations are allowed (at least for now).

Erlay simulations can be run by simply calling the simulator with the `erlay` parameter