### PR TITLE
lib: Fix coefficient of variation for our network latency function

### DIFF
--- a/hyper-lib/src/simulator.rs
+++ b/hyper-lib/src/simulator.rs
@@ -78,9 +78,8 @@ impl Simulator {
 
         // Create a network delay function for sent/received messages. This is in the order of
         // nanoseconds, using a LogNormal distribution with expected value NET_DELAY_MEAN, and
-        // variance NET_DELAY_MEAN/5
-        let net_delay_fn: LogNormal<f64> =
-            LogNormal::from_mean_cv(NET_DELAY_MEAN, NET_DELAY_MEAN * 0.2).unwrap();
+        // variance of 20% of the expected value
+        let net_delay_fn: LogNormal<f64> = LogNormal::from_mean_cv(NET_DELAY_MEAN, 0.2).unwrap();
 
         Self {
             rng,


### PR DESCRIPTION
## Rationale

Looking at the network delays I realized that the values added to the messages passed between peers were really dispersed, and more often than not, drastically small. In many cases, messages were sent and received at the exact same unite of discrete time, when the expected value for the network latency was 10ms (with a 20% variance).

It turns out our probability distribution (LogNormal) was not properly constructed.

The value passed to our LogNormal constructor was not the variance, but the coefficient of variation, which is defined as `σ / μ`. We were defining `σ=02*μ`, hence, 1cv = 0.2*μ/μ = 0.21
