### PR TITLE
sim: Removes short option for `--no-latency`

### DIFF
--- a/hyperion/src/cli.rs
+++ b/hyperion/src/cli.rs
@@ -32,7 +32,7 @@ pub struct Cli {
     #[clap(long, short)]
     pub seed: Option<u64>,
     /// Don't add network latency to messages exchanges between peers. Useful for debugging
-    #[clap(long, short)]
+    #[clap(long)]
     pub no_latency: bool,
 }
 


### PR DESCRIPTION
Close #10 