### PR TITLE
Allow simulations to run multiple times

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Options:
           The number of reachable nodes in the simulated network [default: 10000]
   -u, --unreachable <UNREACHABLE>
           The number of unreachable nodes in the simulated network [default: 100000]
-  -o, outbounds_count <OUTBOUNDS_COUNT>
+  -o, --outbounds <OUTBOUNDS>
           The number of outbound connections established per node [default: 8]
   -l, --log-level <LOG_LEVEL>
           Level of verbosity of the messages displayed by the simulator.
@@ -52,6 +52,8 @@ Options:
           Seed to run random activity generator deterministically
       --no-latency
           Don't add network latency to messages exchanges between peers. Useful for debugging
+  -n, --n <N>
+          Number of times the simulation will be repeated. Smooths the statistical results [default: 1]
   -h, --help
           Print help
   -V, --version

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Options:
           The number of reachable nodes in the simulated network [default: 10000]
   -u, --unreachable <UNREACHABLE>
           The number of unreachable nodes in the simulated network [default: 100000]
-  -n, --num-outbounds <NUM_OUTBOUNDS>
+  -o, outbounds_count <OUTBOUNDS_COUNT>
           The number of outbound connections established per node [default: 8]
   -l, --log-level <LOG_LEVEL>
           Level of verbosity of the messages displayed by the simulator.

--- a/hyper-lib/src/network.rs
+++ b/hyper-lib/src/network.rs
@@ -109,6 +109,7 @@ impl std::fmt::Display for NetworkMessage {
 pub struct Network {
     /// Collection of nodes that composes the simulated network
     nodes: Vec<Node>,
+    is_erlay: bool,
     reachable_count: usize,
 }
 
@@ -138,8 +139,8 @@ impl Network {
         let peers_die = Uniform::from(0..reachable_nodes.len());
 
         log::info!(
-            "Connecting unreachable nodes to reachable ({} connections)",
-            unreachable_count * outbounds_count
+            "Connecting unreachable nodes to reachable ({} outbounds per node)",
+            outbounds_count
         );
         Network::connect_unreachable(
             &mut unreachable_nodes,
@@ -151,8 +152,8 @@ impl Network {
         );
 
         log::info!(
-            "Connecting reachable nodes to reachable ({} connections)",
-            reachable_count * outbounds_count
+            "Connecting reachable nodes to reachable ({} outbounds per node)",
+            outbounds_count
         );
         Network::connect_reachable(
             &mut reachable_nodes,
@@ -162,13 +163,23 @@ impl Network {
             &peers_die,
         );
 
+        log::info!(
+            "Created a total of {} links between nodes",
+            (unreachable_count + reachable_count) * outbounds_count
+        );
+
         let mut nodes = reachable_nodes;
         nodes.extend(unreachable_nodes);
 
         Self {
             nodes,
+            is_erlay,
             reachable_count,
         }
+    }
+
+    pub fn is_erlay(&self) -> bool {
+        self.is_erlay
     }
 
     /// Connects a collection of unreachable nodes to a collection of reachable ones.

--- a/hyper-lib/src/network.rs
+++ b/hyper-lib/src/network.rs
@@ -116,7 +116,7 @@ impl Network {
     pub fn new(
         reachable_count: usize,
         unreachable_count: usize,
-        num_outbounds: usize,
+        outbounds_count: usize,
         is_erlay: bool,
         rng: &mut StdRng,
     ) -> Self {
@@ -139,12 +139,12 @@ impl Network {
 
         log::info!(
             "Connecting unreachable nodes to reachable ({} connections)",
-            unreachable_count * num_outbounds
+            unreachable_count * outbounds_count
         );
         Network::connect_unreachable(
             &mut unreachable_nodes,
             &mut reachable_nodes,
-            num_outbounds,
+            outbounds_count,
             is_erlay,
             rng,
             &peers_die,
@@ -152,11 +152,11 @@ impl Network {
 
         log::info!(
             "Connecting reachable nodes to reachable ({} connections)",
-            reachable_count * num_outbounds
+            reachable_count * outbounds_count
         );
         Network::connect_reachable(
             &mut reachable_nodes,
-            num_outbounds,
+            outbounds_count,
             is_erlay,
             rng,
             &peers_die,
@@ -177,14 +177,14 @@ impl Network {
     fn connect_unreachable(
         unreachable_nodes: &mut [Node],
         reachable_nodes: &mut [Node],
-        num_outbounds: usize,
+        outbounds_count: usize,
         are_erlay: bool,
         rng: &mut StdRng,
         dist: &Uniform<NodeId>,
     ) {
         for node in unreachable_nodes.iter_mut() {
             let mut already_connected_to = HashSet::new();
-            for _ in 0..num_outbounds {
+            for _ in 0..outbounds_count {
                 let peer_id = Network::get_peer_to_connect(&mut already_connected_to, rng, dist);
                 node.connect(peer_id, are_erlay);
                 reachable_nodes
@@ -202,7 +202,7 @@ impl Network {
     /// Nodes to be connected to are picked at random given an uniform distribution [dist]
     fn connect_reachable(
         reachable_nodes: &mut [Node],
-        num_outbounds: usize,
+        outbounds_count: usize,
         are_erlay: bool,
         rng: &mut StdRng,
         dist: &Uniform<NodeId>,
@@ -215,7 +215,7 @@ impl Network {
                 .collect::<HashSet<_>>();
             already_connected_to.insert(node_id);
 
-            for _ in 0..num_outbounds {
+            for _ in 0..outbounds_count {
                 let peer_id = Network::get_peer_to_connect(&mut already_connected_to, rng, dist);
 
                 let (node, peer) = if peer_id < node_id {

--- a/hyper-lib/src/node.rs
+++ b/hyper-lib/src/node.rs
@@ -166,6 +166,7 @@ impl Node {
             node_statistics: NodeStatistics::new(),
         }
     }
+
     /// Gets the next discrete time when a transaction announcement needs to be sent to a given peer.
     /// A [peer_id] is required if the query is performed for an outbound peer, otherwise the request is
     /// assumed to be for inbounds. The method will sample a new time if we have reached the old sample,

--- a/hyper-lib/src/simulator.rs
+++ b/hyper-lib/src/simulator.rs
@@ -71,7 +71,7 @@ impl Simulator {
     pub fn new(
         reachable_count: usize,
         unreachable_count: usize,
-        num_outbound: usize,
+        outbounds_count: usize,
         is_erlay: bool,
         current_time: u64,
         seed: Option<u64>,
@@ -89,7 +89,7 @@ impl Simulator {
         let mut network = Network::new(
             reachable_count,
             unreachable_count,
-            num_outbound,
+            outbounds_count,
             is_erlay,
             &mut rng,
         );

--- a/hyper-lib/src/simulator.rs
+++ b/hyper-lib/src/simulator.rs
@@ -73,7 +73,6 @@ impl Simulator {
         unreachable_count: usize,
         outbounds_count: usize,
         is_erlay: bool,
-        current_time: u64,
         seed: Option<u64>,
         network_latency: bool,
     ) -> Self {
@@ -86,27 +85,13 @@ impl Simulator {
             s
         };
         let mut rng: StdRng = StdRng::seed_from_u64(seed);
-        let mut network = Network::new(
+        let network = Network::new(
             reachable_count,
             unreachable_count,
             outbounds_count,
             is_erlay,
             &mut rng,
         );
-
-        let mut event_queue = PriorityQueue::new();
-        if is_erlay {
-            for node in network.get_nodes_mut() {
-                // Schedule transaction reconciliation here. As opposite to fanout, reconciliation is scheduled
-                // on a fixed interval. This means that we need to start it when the connection is made. However,
-                // in the simulator, the whole network is build at the same (discrete) time. This does not follow
-                // reality, so we will pick a random value between the simulation start time (current_time) and
-                // RECON_REQUEST_INTERVAL as the first scheduled reconciliation for each connection.
-                let delta = rng.gen_range(0..RECON_REQUEST_INTERVAL * SECS_TO_NANOS);
-                let (e, t) = node.schedule_set_reconciliation(current_time + delta);
-                event_queue.push(e, Reverse(t));
-            }
-        }
 
         // Create a network latency function for sent/received messages. This is in the order of
         // nanoseconds, using a LogNormal distribution with expected value NET_LATENCY_MEAN, and
@@ -121,7 +106,24 @@ impl Simulator {
             rng,
             net_latency_fn,
             network,
-            event_queue,
+            event_queue: PriorityQueue::new(),
+        }
+    }
+
+    pub fn schedule_set_reconciliation(&mut self, current_time: u64) {
+        if self.network.is_erlay() {
+            for node in self.network.get_nodes_mut() {
+                // Schedule transaction reconciliation here. As opposite to fanout, reconciliation is scheduled
+                // on a fixed interval. This means that we need to start it when the connection is made. However,
+                // in the simulator, the whole network is build at the same (discrete) time. This does not follow
+                // reality, so we will pick a random value between the simulation start time (current_time) and
+                // RECON_REQUEST_INTERVAL as the first scheduled reconciliation for each connection.
+                let delta = self
+                    .rng
+                    .gen_range(0..RECON_REQUEST_INTERVAL * SECS_TO_NANOS);
+                let (e, t) = node.schedule_set_reconciliation(current_time + delta);
+                self.event_queue.push(e, Reverse(t));
+            }
         }
     }
 

--- a/hyperion/src/cli.rs
+++ b/hyperion/src/cli.rs
@@ -20,7 +20,7 @@ pub struct Cli {
     pub unreachable: usize,
     /// The number of outbound connections established per node.
     #[clap(long, short, default_value_t = MAX_OUTBOUND_CONNECTIONS)]
-    pub num_outbounds: usize,
+    pub outbounds: usize,
     /// Level of verbosity of the messages displayed by the simulator.
     /// Possible values: [off, error, warn, info, debug, trace]
     #[clap(long, short, verbatim_doc_comment, default_value = "info")]
@@ -41,7 +41,7 @@ pub struct Cli {
 
 impl Cli {
     pub fn verify(&self) {
-        assert!(self.reachable >= 10 * self.num_outbounds,
+        assert!(self.reachable >= 10 * self.outbounds,
             "Too few reachable peers. In order to allow enough randomness in the network topology generation, please make sure
             the number of reachable nodes is, at least, 10 times the number of outbound connections per node");
     }

--- a/hyperion/src/cli.rs
+++ b/hyperion/src/cli.rs
@@ -37,6 +37,9 @@ pub struct Cli {
     /// Don't add network latency to messages exchanges between peers. Useful for debugging
     #[clap(long)]
     pub no_latency: bool,
+    /// Number of times the simulation will be repeated. Smooths the statistical results
+    #[clap(long, short, default_value_t = 1)]
+    pub n: u32,
 }
 
 impl Cli {

--- a/hyperion/src/main.rs
+++ b/hyperion/src/main.rs
@@ -22,7 +22,7 @@ fn main() -> anyhow::Result<()> {
     let mut simulator = Simulator::new(
         cli.reachable,
         cli.unreachable,
-        cli.num_outbounds,
+        cli.outbounds,
         cli.erlay,
         start_time,
         cli.seed,

--- a/hyperion/src/main.rs
+++ b/hyperion/src/main.rs
@@ -17,127 +17,155 @@ fn main() -> anyhow::Result<()> {
         .init()
         .unwrap();
 
-    let start_time = 0;
     let node_count = cli.reachable + cli.unreachable;
+    let target_node_count = node_count as f32 * (cli.percentile_target as f32 / 100.0);
     let mut simulator = Simulator::new(
         cli.reachable,
         cli.unreachable,
         cli.outbounds,
         cli.erlay,
-        start_time,
         cli.seed,
         !cli.no_latency,
     );
 
     // Pick a (source) node to broadcast the target transaction from.
-    let txid = simulator.get_random_txid();
     let source_node_id = simulator.get_random_nodeid();
-    let source_node = simulator.get_node_mut(source_node_id).unwrap();
-
-    log::info!(
-        "Starting simulation: broadcasting transaction (txid: {txid:x}) from node {source_node_id}"
-    );
-    for (event, time) in source_node.broadcast_tx(txid, start_time) {
-        simulator.add_event(event, time);
+    log::info!("Starting simulation: broadcasting transaction from node {source_node_id}");
+    if cli.n > 1 {
+        log::info!(
+            "The simulation will be run {} times and results will be averaged",
+            cli.n
+        );
     }
 
-    // For statistical purposes
-    let mut nodes_reached = 1;
-    let mut percentile_time = 0;
-    let target_node_count = node_count as f32 * (cli.percentile_target as f32 / 100.0);
+    let start_time = 0;
+    let mut overall_time = 0;
+    let mut txid = simulator.get_random_txid();
+    let mut sent_txs = Vec::new();
+    for _ in 0..cli.n {
+        // For statistical purposes
+        let mut nodes_reached = 1;
+        let mut percentile_time = 0;
 
-    // Process events until the queue is empty
-    while let Some((event, time)) = simulator.get_next_event() {
-        match event {
-            Event::ReceiveMessageFrom(src, dst, msg) => {
-                if msg.is_tx() && percentile_time == 0 {
-                    nodes_reached += 1;
-                    if nodes_reached as f32 >= target_node_count {
-                        percentile_time = time;
+        // Bootstrap the set reconciliation events (if needed) and send out the transaction.
+        // All simulations start at time 0 so we don't have to carry any offset when computing
+        // the overall time
+        simulator.schedule_set_reconciliation(start_time);
+        for (event, time) in simulator
+            .get_node_mut(source_node_id)
+            .unwrap()
+            .broadcast_tx(txid, start_time)
+        {
+            simulator.add_event(event, time);
+        }
+
+        // Process events until the queue is empty
+        while let Some((event, event_time)) = simulator.get_next_event() {
+            match event {
+                Event::ReceiveMessageFrom(src, dst, msg) => {
+                    if msg.is_tx() && percentile_time == 0 {
+                        nodes_reached += 1;
+                        if nodes_reached as f32 >= target_node_count {
+                            percentile_time = event_time;
+                        }
+                    }
+                    for (future_event, future_time) in simulator
+                        .network
+                        .get_node_mut(dst)
+                        .unwrap()
+                        .receive_message_from(msg, src, event_time)
+                    {
+                        simulator.add_event(future_event, future_time);
                     }
                 }
-                for (future_event, future_time) in simulator
-                    .network
-                    .get_node_mut(dst)
-                    .unwrap()
-                    .receive_message_from(msg, src, time)
-                {
-                    simulator.add_event(future_event, future_time);
-                }
-            }
-            Event::ProcessScheduledAnnouncement(src, dst) => {
-                if let Some((scheduled_event, t)) = simulator
-                    .network
-                    .get_node_mut(src)
-                    .unwrap()
-                    .process_scheduled_announcement(dst, time)
-                {
-                    simulator.add_event(scheduled_event, t);
-                }
-            }
-            Event::ProcessDelayedRequest(target, txid) => {
-                if let Some((delayed_event, next_interval)) = simulator
-                    .network
-                    .get_node_mut(target)
-                    .unwrap()
-                    .process_delayed_request(txid, time)
-                {
-                    simulator.add_event(delayed_event, next_interval);
-                }
-            }
-            Event::ProcessScheduledReconciliation(src) => {
-                // Drop the periodic schedule if there is nothing else to be reconciled
-                // This allow us to finish the simulation, for Erlay scenarios, by consuming
-                // all messages in the queue
-                let node = simulator.network.get_node(src).unwrap();
-                if !node.knows_transaction(&txid)
-                    || !node.get_outbounds().keys().all(|node_id| {
-                        simulator
-                            .network
-                            .get_node(*node_id)
-                            .unwrap()
-                            .knows_transaction(&txid)
-                    })
-                {
-                    // Processing an scheduled reconciliation will return the reconciliation flow
-                    // start, plus the scheduling of the next reconciliation (with the next peer in line)
-                    let ((rec_req, req_time), (next_event, future_time)) = simulator
+                Event::ProcessScheduledAnnouncement(src, dst) => {
+                    if let Some((scheduled_event, t)) = simulator
                         .network
                         .get_node_mut(src)
                         .unwrap()
-                        .process_scheduled_reconciliation(time);
-                    simulator.add_event(rec_req, req_time);
-                    simulator.add_event(next_event, future_time);
+                        .process_scheduled_announcement(dst, event_time)
+                    {
+                        simulator.add_event(scheduled_event, t);
+                    }
+                }
+                Event::ProcessDelayedRequest(target, txid) => {
+                    if let Some((delayed_event, next_interval)) = simulator
+                        .network
+                        .get_node_mut(target)
+                        .unwrap()
+                        .process_delayed_request(txid, event_time)
+                    {
+                        simulator.add_event(delayed_event, next_interval);
+                    }
+                }
+                Event::ProcessScheduledReconciliation(src) => {
+                    // Drop the periodic schedule if there is nothing else to be reconciled
+                    // This allow us to finish the simulation, for Erlay scenarios, by consuming
+                    // all messages in the queue
+                    let node = simulator.network.get_node(src).unwrap();
+                    if !node.knows_transaction(&txid)
+                        || !node.get_outbounds().keys().all(|node_id| {
+                            simulator
+                                .network
+                                .get_node(*node_id)
+                                .unwrap()
+                                .knows_transaction(&txid)
+                        })
+                    {
+                        // Processing an scheduled reconciliation will return the reconciliation flow
+                        // start, plus the scheduling of the next reconciliation (with the next peer in line)
+                        let ((rec_req, req_time), (next_event, future_time)) = simulator
+                            .network
+                            .get_node_mut(src)
+                            .unwrap()
+                            .process_scheduled_reconciliation(event_time);
+                        simulator.add_event(rec_req, req_time);
+                        simulator.add_event(next_event, future_time);
+                    }
                 }
             }
         }
+
+        // Make sure every node has received the transaction
+        for node in simulator.network.get_nodes() {
+            assert!(node.knows_transaction(&txid));
+        }
+
+        // Pick a new txid for the next iteration (if any)
+        if cli.n > 1 {
+            sent_txs.push(txid);
+            let mut new_txid = simulator.get_random_txid();
+            while sent_txs.contains(&new_txid) {
+                new_txid = simulator.get_random_txid();
+            }
+            txid = new_txid;
+        }
+
+        assert_ne!(percentile_time, 0);
+        overall_time += percentile_time;
     }
 
-    // Make sure every node has received the transaction
-    for node in simulator.network.get_nodes() {
-        assert!(node.knows_transaction(&txid));
-    }
+    let avg_percentile_time = (overall_time as f32 / cli.n as f32).round() as u64;
+    log::info!(
+        "Transaction reached {}% of nodes in the network in {}s",
+        cli.percentile_target,
+        time::Duration::from_nanos(avg_percentile_time).as_secs_f32(),
+    );
 
     let statistics = simulator.network.get_statistics();
     log::info!(
         "Reachable nodes sent/received {}/{} messages ({}/{} bytes) (avg)",
-        statistics.avg_messages().sent_reachable(),
-        statistics.avg_messages().received_reachable(),
-        statistics.avg_bytes().sent_reachable(),
-        statistics.avg_bytes().received_reachable(),
+        statistics.avg_messages().sent_reachable() / cli.n as f32,
+        statistics.avg_messages().received_reachable() / cli.n as f32,
+        statistics.avg_bytes().sent_reachable() / cli.n as f32,
+        statistics.avg_bytes().received_reachable() / cli.n as f32,
     );
     log::info!(
         "Unreachable nodes sent/received {}/{} messages ({}/{} bytes) (avg)",
-        statistics.avg_messages().sent_unreachable(),
-        statistics.avg_messages().received_unreachable(),
-        statistics.avg_bytes().sent_unreachable(),
-        statistics.avg_bytes().received_unreachable(),
-    );
-
-    log::info!(
-        "Transaction (txid: {txid:x}) reached {}% of nodes in the network in {}s",
-        cli.percentile_target,
-        time::Duration::from_nanos(percentile_time).as_secs_f32(),
+        statistics.avg_messages().sent_unreachable() / cli.n as f32,
+        statistics.avg_messages().received_unreachable() / cli.n as f32,
+        statistics.avg_bytes().sent_unreachable() / cli.n as f32,
+        statistics.avg_bytes().received_unreachable() / cli.n as f32,
     );
 
     Ok(())


### PR DESCRIPTION
If `n` is passed, the simulator will be run `n` simulations. The statistical results will be an average of all the runs.

The same network and source node will be used to send all transactions over the `n` runs in order to minimize the variance between the results.