### PR TITLE
sim: Enforce a minimum reachable to non-reachable node ratio

### DIFF
--- a/hyper-lib/src/simulator.rs
+++ b/hyper-lib/src/simulator.rs
@@ -71,6 +71,7 @@ impl Simulator {
     pub fn new(
         reachable_count: usize,
         unreachable_count: usize,
+        num_outbound: usize,
         is_erlay: bool,
         current_time: u64,
         seed: Option<u64>,
@@ -85,7 +86,13 @@ impl Simulator {
             s
         };
         let mut rng: StdRng = StdRng::seed_from_u64(seed);
-        let mut network = Network::new(reachable_count, unreachable_count, is_erlay, &mut rng);
+        let mut network = Network::new(
+            reachable_count,
+            unreachable_count,
+            num_outbound,
+            is_erlay,
+            &mut rng,
+        );
 
         let mut event_queue = PriorityQueue::new();
         if is_erlay {

--- a/hyperion/src/cli.rs
+++ b/hyperion/src/cli.rs
@@ -41,7 +41,7 @@ pub struct Cli {
 
 impl Cli {
     pub fn verify(&self) {
-        assert!(self.reachable < 10 * self.num_outbounds,
+        assert!(self.reachable >= 10 * self.num_outbounds,
             "Too few reachable peers. In order to allow enough randomness in the network topology generation, please make sure
             the number of reachable nodes is, at least, 10 times the number of outbound connections per node");
     }

--- a/hyperion/src/main.rs
+++ b/hyperion/src/main.rs
@@ -8,6 +8,7 @@ use hyperion::cli::Cli;
 
 fn main() -> anyhow::Result<()> {
     let cli = Cli::parse();
+    cli.verify();
 
     SimpleLogger::new()
         .with_level(LevelFilter::Warn)
@@ -21,6 +22,7 @@ fn main() -> anyhow::Result<()> {
     let mut simulator = Simulator::new(
         cli.reachable,
         cli.unreachable,
+        cli.num_outbounds,
         cli.erlay,
         start_time,
         cli.seed,


### PR DESCRIPTION
Part of the functionality was introduced in https://github.com/sr-gi/hyperion/commit/b51a81b9686281d00c95b27e17b9078613e0d205 but not enforced. Pass the parameter around and make sure the minimum ratio holds