### PR TITLE
multi: Restart peers' timers on re-run

### DIFF
--- a/hyper-lib/src/node.rs
+++ b/hyper-lib/src/node.rs
@@ -167,6 +167,13 @@ impl Node {
         }
     }
 
+    pub fn reset_timers(&mut self) {
+        self.inbounds_poisson_timer.next_interval = 0;
+        for timer in self.outbounds_poisson_timers.values_mut() {
+            timer.next_interval = 0;
+        }
+    }
+
     /// Gets the next discrete time when a transaction announcement needs to be sent to a given peer.
     /// A [peer_id] is required if the query is performed for an outbound peer, otherwise the request is
     /// assumed to be for inbounds. The method will sample a new time if we have reached the old sample,

--- a/hyperion/src/main.rs
+++ b/hyperion/src/main.rs
@@ -31,7 +31,15 @@ fn main() -> anyhow::Result<()> {
 
     // Pick a (source) node to broadcast the target transaction from.
     let source_node_id = simulator.get_random_nodeid();
-    log::info!("Starting simulation: broadcasting transaction from node {source_node_id}");
+    let reachable_source = source_node_id < cli.reachable;
+    log::info!(
+        "Starting simulation: broadcasting transaction from node {source_node_id} ({})",
+        if reachable_source {
+            "reachable"
+        } else {
+            "unreachable"
+        }
+    );
     if cli.n > 1 {
         log::info!(
             "The simulation will be run {} times and results will be averaged",
@@ -153,6 +161,10 @@ fn main() -> anyhow::Result<()> {
 
         assert_ne!(percentile_time, 0);
         overall_time += percentile_time;
+
+        for node in simulator.network.get_nodes_mut() {
+            node.reset_timers();
+        }
     }
 
     let avg_percentile_time = (overall_time as f32 / cli.n as f32).round() as u64;


### PR DESCRIPTION
Simulation multi-runs were re-setting the simulation start time, but not the peers' timers next_time, meaning that each re-run will pick up from where the last simulation left it. Fix timers so they start at zero every re-run