### PR TITLE
lib: Add networks links (and latencies) to Network 

### DIFF
--- a/hyper-lib/src/node.rs
+++ b/hyper-lib/src/node.rs
@@ -751,15 +751,13 @@ impl Node {
         // message event for a peer
         if let Some((event, _)) = &message {
             if let Some(msg) = event.get_message() {
-                if event.is_receive_message() {
-                    debug_log!(
-                        request_time,
-                        self.node_id,
-                        "Sending {msg} to peer {peer_id}"
-                    );
-                    self.node_statistics
-                        .add_sent(msg, self.is_peer_inbounds(&peer_id));
-                }
+                debug_log!(
+                    request_time,
+                    self.node_id,
+                    "Sending {msg} to peer {peer_id}"
+                );
+                self.node_statistics
+                    .add_sent(msg, self.is_peer_inbounds(&peer_id));
             }
         }
 


### PR DESCRIPTION
Currently, the concept of a link between two nodes is implicit from the network's
perspective: both ends of the link have each other as either inbound or outbound peers,
but there is no accounting of it at the network level. Network latencies are, therefore,
assigned at a per-message level, making it possible for messages that travel through a
common link to be received in a different order than they were sent. Even though this is
not too common, it is undesirable.

Create an explicit definition of link, and assign fixed, but random, network latencies to them
such that all messages traversing a common link maintain their ordering*.

This also makes it easier to create topologies with user-defined link latencies, as opposed to
the previous approach

\* Links will be created even if the simulation is run with `--no-latency`, but they'll be assigned
0 latency and the access to the collection will be bypassed. This is just to maintain the interface
in case the links themselves are useful in the future