### PR TITLE
multi: Replaces PriorityQueue for BinaryHeap

### DIFF
--- a/hyper-lib/Cargo.toml
+++ b/hyper-lib/Cargo.toml
@@ -13,7 +13,6 @@ Supporting library for hyperion: a discrete time network event simulator for Bit
 graphrs = "0.9.0"
 itertools = "0.13.0"
 log = "0.4.20"
-priority-queue = "2.0.3"
 rand = "0.8.5"
 rand_distr = "0.4.3"
 simple_logger = "5.0.0"


### PR DESCRIPTION
The same functionality can be achieved with BinaryHeap, which is part of std, plus it is slightly faster.

 Also encapsulates (Event, u64) in ScheduledEvent.

Overall this achieves slightly better performance (as in simulations take less time to run)