### PR TITLE
sim: Properly defines first seen time

### DIFF
--- a/hyper-lib/src/simulator.rs
+++ b/hyper-lib/src/simulator.rs
@@ -185,6 +185,12 @@ impl Simulator {
         self.event_queue.pop()
     }
 
+    /// Get the time when the next event will be processed
+    pub fn get_next_event_time(&mut self) -> Option<u64> {
+        let scheduled_event = self.event_queue.peek()?;
+        Some(scheduled_event.time())
+    }
+
     pub fn get_random_txid(&mut self) -> TxId {
         self.rng.next_u32()
     }

--- a/hyperion/src/main.rs
+++ b/hyperion/src/main.rs
@@ -76,6 +76,9 @@ fn main() -> anyhow::Result<()> {
         {
             simulator.add_event(e);
         }
+        // Record the initial time as the time when the first node sends out the transaction.
+        // We don't need to account for the time the source withholds it
+        let first_seen_time = simulator.get_next_event_time().unwrap();
 
         // Process events until the queue is empty
         while let Some(scheduled_event) = simulator.get_next_event() {
@@ -85,7 +88,7 @@ fn main() -> anyhow::Result<()> {
                     if msg.is_tx() && percentile_time == 0 {
                         nodes_reached += 1;
                         if nodes_reached as f32 >= target_node_count {
-                            percentile_time = current_time;
+                            percentile_time = current_time - first_seen_time;
                         }
                     }
                     for future_event in simulator


### PR DESCRIPTION
Currently, the propagation time is defined as the time between a transaction being created and it being received by a certain percentage of the network. However, the time the node originator initially withholds that transaction should not be taken into account. The time should be counted from when the node broadcasts the transaction.

Account for this as the time the first node receives the transaction minus the link latency