### PR TITLE
Simplifies the simulator design to provide better performance

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,3 +5,7 @@ members = [
     "hyper-lib",
     "hyperion",
 ]
+
+[profile.release-with-debug]
+inherits = "release"
+debug = true

--- a/hyper-lib/Cargo.toml
+++ b/hyper-lib/Cargo.toml
@@ -11,6 +11,7 @@ Supporting library for hyperion: a discrete time network event simulator for Bit
 [dependencies]
 # FIXME: Move this into a feature
 graphrs = "0.9.0"
+hashbrown = "0.15"
 itertools = "0.13.0"
 log = "0.4.20"
 rand = "0.8.5"

--- a/hyper-lib/src/indexedmap.rs
+++ b/hyper-lib/src/indexedmap.rs
@@ -28,6 +28,10 @@ where
         &self.map
     }
 
+    pub fn inner_mut(&mut self) -> &mut HashMap<K, V> {
+        &mut self.map
+    }
+
     pub fn insert(&mut self, key: K, value: V) -> Option<V> {
         self.order.push(key);
         self.map.insert(key, value)

--- a/hyper-lib/src/indexedmap.rs
+++ b/hyper-lib/src/indexedmap.rs
@@ -1,5 +1,5 @@
-use std::collections::hash_map::Keys;
-use std::collections::HashMap;
+use hashbrown::hash_map::Keys;
+use hashbrown::HashMap;
 use std::hash::Hash;
 
 #[derive(Clone)]

--- a/hyper-lib/src/lib.rs
+++ b/hyper-lib/src/lib.rs
@@ -11,13 +11,3 @@ pub type TxId = u32;
 
 pub const MAX_OUTBOUND_CONNECTIONS: usize = 8;
 static SECS_TO_NANOS: u64 = 1_000_000_000;
-
-#[cfg(test)]
-mod test {
-    use super::*;
-    use rand::{self, RngCore};
-
-    pub(crate) fn get_random_txid() -> TxId {
-        rand::thread_rng().next_u32()
-    }
-}

--- a/hyper-lib/src/network.rs
+++ b/hyper-lib/src/network.rs
@@ -3,7 +3,7 @@ use crate::statistics::NetworkStatistics;
 use crate::txreconciliation::{ShortID, Sketch};
 use crate::{TxId, SECS_TO_NANOS};
 
-use std::collections::{HashMap, HashSet};
+use hashbrown::{HashMap, HashSet};
 
 use itertools::Itertools;
 use rand::rngs::StdRng;

--- a/hyper-lib/src/network.rs
+++ b/hyper-lib/src/network.rs
@@ -1,11 +1,10 @@
 use crate::node::{Node, NodeId};
 use crate::statistics::NetworkStatistics;
-use crate::txreconciliation::{ShortID, Sketch};
-use crate::{TxId, SECS_TO_NANOS};
+use crate::txreconciliation::Sketch;
+use crate::SECS_TO_NANOS;
 
 use hashbrown::{HashMap, HashSet};
 
-use itertools::Itertools;
 use rand::rngs::StdRng;
 use rand_distr::{Distribution, LogNormal, Uniform};
 
@@ -53,15 +52,17 @@ impl From<(NodeId, NodeId)> for Link {
 /// Defines the collection of network messages that can be exchanged between peers
 #[derive(Clone, PartialEq, Eq, Hash, Debug)]
 pub enum NetworkMessage {
-    INV(Vec<TxId>),
-    GETDATA(Vec<TxId>),
-    TX(TxId),
-    // This is a hack. REQRECON does not include a collection of short ids (that'd defuse the purpose of Erlay). However,
+    INV,
+    GETDATA,
+    TX,
+    // This is a hack. REQRECON does not include any transaction related data (that'd defuse the purpose of Erlay). However,
     // for simulation purposes we need to estimate the set difference (q). A workaround for that is letting the peer
     // know what we know so it can be always perfectly "predicted", and scale it to a chosen factor later on if we chose to
-    REQRECON(Vec<ShortID>),
+    REQRECON(bool),
     SKETCH(Sketch),
-    RECONCILDIFF(Vec<ShortID>),
+    // This is also a hack. RECONCILDIFF would usually have the difference between the two sets, but given we are simulating
+    // a single transaction, this could be simplified to a bool signaling whether that transaction was in the senders set or not
+    RECONCILDIFF(bool),
 }
 
 impl NetworkMessage {
@@ -70,51 +71,52 @@ impl NetworkMessage {
     pub fn get_size(&self) -> usize {
         // Fanout messages:
         //      To make it fair game with Erlay related messages, we will only count the amount of
-        //      data each transactions contributes to a message, so we will drop the fixed overhead
+        //      data each transaction contributes to a message, so we will drop the fixed overhead
         //      (that is, message header, input count, ...).
         //      Notice we are even counting the transaction size as zero, because each node will receive
         //      it exactly once. This means that the overhead is constant.
         // Erlay messages:
         //      For Erlay related messages, the reconciliation flow is run (and messages are exchanged)
-        //      independently of whether there are transactions to be exchanged or not (as opposite to
+        //      independently of whether there is a transaction to be exchanged or not (as opposite to
         //      the fanout flow). Being this the case, the simulator won't count the size of REQRECON
         //      messages, given they are independent of the amount of transactions being reconciled.
         //      For SKETCH messages, we will count the growth of the sketch based on the difference q,
         //      and for RECONCILDIFF we will count size of the difference.
         match self {
             // Type of entry + hash (4+32 bytes) * number of entries
-            NetworkMessage::INV(x) => 36 * x.len(),
+            NetworkMessage::INV => 36,
             // Type of entry + hash (4+32 bytes) * number of entries
-            NetworkMessage::GETDATA(x) => 36 * x.len(),
+            NetworkMessage::GETDATA => 36,
             // Each node will receive the transaction exactly once, we can count this as zero
-            NetworkMessage::TX(_) => 0,
+            NetworkMessage::TX => 0,
             // Not counting the size of periodic requests, check the previous comment for rationale
             NetworkMessage::REQRECON(_) => 0,
             // The sketch size is based on the expected difference of the sets, 4-bytes per count
             NetworkMessage::SKETCH(s) => s.get_size() * 4,
             // 1 byte signaling whether the received sketch could ber properly decoded, plus n bytes,
-            // depending on the number of missing transactions (8 bytes per count)
+            // depending on the number of missing transactions (4 bytes per count)
             // Notice `RECONCILDIFF` doesn't include the success byte, because we assume the decoding
             // always succeeds in our simulations
-            NetworkMessage::RECONCILDIFF(ask_ids) => 1 + ask_ids.len() * 4,
+            NetworkMessage::RECONCILDIFF(ask_ids) => 1 + (*ask_ids as usize) * 4,
         }
     }
 
     /// Returns whether the network message is a inventory message
     pub fn is_inv(&self) -> bool {
-        matches!(self, NetworkMessage::INV(..))
+        matches!(self, NetworkMessage::INV)
     }
 
     /// Returns whether the network message is a data request message
     pub fn is_get_data(&self) -> bool {
-        matches!(self, NetworkMessage::GETDATA(..))
+        matches!(self, NetworkMessage::GETDATA)
     }
 
     /// Returns whether the network message is transaction message
     pub fn is_tx(&self) -> bool {
-        matches!(self, NetworkMessage::TX(..))
+        matches!(self, NetworkMessage::TX)
     }
 
+    // Returns whether the network message is an Erlay message
     pub fn is_erlay(&self) -> bool {
         matches!(self, NetworkMessage::REQRECON(..))
             || matches!(self, NetworkMessage::SKETCH(..))
@@ -124,26 +126,15 @@ impl NetworkMessage {
 
 impl std::fmt::Display for NetworkMessage {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let (m, txs) = match self {
-            NetworkMessage::INV(x) => ("inv", format!("txids: [{:x}]", x.iter().format(", "))),
-            NetworkMessage::GETDATA(x) => {
-                ("getdata", format!("txids: [{:x}]", x.iter().format(", ")))
-            }
-            NetworkMessage::TX(x) => ("tx", format!("txid: {:x}", x)),
-            NetworkMessage::REQRECON(x) => {
-                ("reqrecon", format!("txids: [{:x}]", x.iter().format(", ")))
-            }
-            NetworkMessage::SKETCH(s) => (
-                "sketch",
-                format!("txids: [{:x}]", s.get_tx_set().iter().format(", ")),
-            ),
-            NetworkMessage::RECONCILDIFF(x) => (
-                "reconcildiff",
-                format!("txids: [{:x}]", x.iter().format(", ")),
-            ),
+        let m = match self {
+            NetworkMessage::INV => "inv",
+            NetworkMessage::GETDATA => "getdata",
+            NetworkMessage::TX => "tx",
+            NetworkMessage::REQRECON(x) => &format!("reqrecon ({x})"),
+            NetworkMessage::SKETCH(s) => &format!("sketch ({})", s.get_tx_set()),
+            NetworkMessage::RECONCILDIFF(x) => &format!("reconcildiff ({})", x),
         };
-
-        write!(f, "{m} ({txs})")
+        write!(f, "{m}",)
     }
 }
 

--- a/hyper-lib/src/node.rs
+++ b/hyper-lib/src/node.rs
@@ -1,6 +1,7 @@
-use std::collections::hash_map::{DefaultHasher, Entry};
-use std::collections::{HashMap, HashSet};
-use std::hash::Hasher;
+use hashbrown::hash_map::Entry;
+use hashbrown::DefaultHashBuilder;
+use hashbrown::{HashMap, HashSet};
+use std::hash::{BuildHasher, Hasher};
 
 use itertools::Itertools;
 use rand::rngs::StdRng;
@@ -302,7 +303,7 @@ impl Node {
         I: Iterator<Item = &'a TxId> + 'a,
     {
         iter.filter(move |txid| {
-            !self.knows_transaction(txid) && !self.requested_transactions.contains(txid)
+            !self.knows_transaction(txid) && !self.requested_transactions.contains(*txid)
         })
     }
 
@@ -322,7 +323,7 @@ impl Node {
         }
 
         // Seed our hasher using the target transaction id
-        let mut deterministic_randomizer = DefaultHasher::new();
+        let mut deterministic_randomizer = DefaultHashBuilder::default().build_hasher();
         deterministic_randomizer.write_u32(txid);
 
         // Also add out own node_id as seed. This is only necessary in the simulator given node_ids

--- a/hyper-lib/src/statistics.rs
+++ b/hyper-lib/src/statistics.rs
@@ -67,9 +67,9 @@ impl NodeStatistics {
 
     fn get_data_ref(&mut self, msg: &NetworkMessage) -> (&mut Data, &mut Data) {
         let data_ref = match msg {
-            NetworkMessage::INV(_) => &mut self.inv,
-            NetworkMessage::GETDATA(_) => &mut self.get_data,
-            NetworkMessage::TX(_) => &mut self.tx,
+            NetworkMessage::INV => &mut self.inv,
+            NetworkMessage::GETDATA => &mut self.get_data,
+            NetworkMessage::TX => &mut self.tx,
             NetworkMessage::REQRECON(_) => &mut self.reqrecon,
             NetworkMessage::SKETCH(_) => &mut self.sketch,
             NetworkMessage::RECONCILDIFF(_) => &mut self.reconcildiff,

--- a/hyper-lib/src/txreconciliation.rs
+++ b/hyper-lib/src/txreconciliation.rs
@@ -1,28 +1,23 @@
-use hashbrown::HashSet;
-
-use itertools::Itertools;
-
-use crate::TxId;
-
 pub type ShortID = u32;
 
-// This is a hack. A sketch is really built using Minisketch. However, this is not necessary for the simulator.
-// The only thing we need to know is what transactions a node knows, and what is the size of the difference between that
-// and the set of transaction its peer knows. The difference can be computed on the fly, but it is stored here so we can keep
-// track of the size of the message for statistics.
-#[derive(Clone, PartialEq, Eq, Hash, Debug)]
+/// This is a hack. A sketch is really built using Minisketch. However, this is not necessary for the simulator.
+/// The only thing we need to know is whether the node knows the transaction, and what is the size of the difference
+/// between that and the set of transaction its peer knows (1 or 0, given we are simulating a single transactions).
+/// The difference can be computed on the fly, but it is stored here so we can keep
+/// track of the size of the message for statistics.
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
 pub struct Sketch {
-    tx_set: Vec<ShortID>,
+    tx_set: bool,
     d: usize,
 }
 
 impl Sketch {
-    pub fn new(tx_set: Vec<TxId>, d: usize) -> Self {
+    pub fn new(tx_set: bool, d: usize) -> Self {
         Self { tx_set, d }
     }
 
-    pub fn get_tx_set(&self) -> &Vec<TxId> {
-        &self.tx_set
+    pub fn get_tx_set(&self) -> bool {
+        self.tx_set
     }
 
     pub fn get_size(&self) -> usize {
@@ -36,14 +31,12 @@ pub struct TxReconciliationState {
     is_initiator: bool,
     /// Whether we are currently reconciling with this peer or not
     is_reconciling: bool,
-    /// Set of transactions to be reconciled with this peer (using Erlay).
-    /// Normally, ShortIDs would be 32 bits as opposed to 256-bit TxIds. However, we are already simplifying
-    /// TxIds to be 32-bit, so here it'd be a one-to-one mapping
-    recon_set: HashSet<ShortID>,
-    // Set of transactions to be added to the reconciliation set on the next trickle. These are still unrequestable for
-    // privacy reasons (to prevent transaction proving), transactions became available once they would have been announced
-    // via fanout (on the next trickle).
-    delayed_set: HashSet<ShortID>,
+    /// Whether the simulated transaction is in the reconciliation set
+    recon_set: bool,
+    /// Whether the simulated transaction is in pending to be added to the reconciliation set the next trickle.
+    /// These is still unrequestable for privacy reasons (to prevent transaction proving), the transaction will became
+    /// available once it would have been announced via fanout (on the next trickle).
+    delayed_set: bool,
 }
 
 impl TxReconciliationState {
@@ -51,36 +44,50 @@ impl TxReconciliationState {
         Self {
             is_initiator,
             is_reconciling: false,
-            recon_set: HashSet::new(),
-            delayed_set: HashSet::new(),
+            recon_set: false,
+            delayed_set: false,
         }
     }
 
-    pub fn clear(&mut self) -> HashSet<ShortID> {
+    pub fn clear(&mut self, include_delayed: bool) -> bool {
+        // The transaction cannot be in both sets at the same time
+        assert!(!(self.recon_set && self.delayed_set));
+
+        let recon_set = self.recon_set;
         self.is_reconciling = false;
-        self.recon_set.drain().collect()
+        self.recon_set = false;
+
+        if include_delayed {
+            self.delayed_set = false;
+        }
+
+        recon_set
     }
 
     pub fn is_initiator(&self) -> bool {
         self.is_initiator
     }
 
-    pub fn add_tx(&mut self, txid: TxId) -> bool {
-        self.delayed_set.insert(txid)
+    pub fn add_tx(&mut self) -> bool {
+        let r = !self.delayed_set;
+        self.delayed_set = true;
+
+        r
     }
 
-    /// Removes a transaction from the reconciliation set. This may happen if a peer has announced a transaction that we
+    /// Removes the transaction from the reconciliation set. This may happen if a peer has announced the transaction that we
     /// were planing to reconcile with them. Notice that, if this happens after creating a snapshot, the reconciliation will
-    /// result in one additional item on the exchanged INV (belonging to this transaction). This is equivalent to two INVs crossing,
-    /// and AFAIK, there's nothing we can do about it
-    pub fn remove_tx(&mut self, txid: &TxId) {
-        self.delayed_set.remove(txid);
-        self.recon_set.remove(txid);
+    /// result in one additional INV (belonging to this transaction). This is equivalent to two INVs crossing, and AFAIK,
+    /// there's nothing we can do about it
+    pub fn remove_tx(&mut self) {
+        self.delayed_set = false;
+        self.recon_set = false;
     }
 
     // Make delayed transactions available for reconciliation
     pub fn make_delayed_available(&mut self) {
-        self.recon_set.extend(self.delayed_set.drain());
+        self.recon_set = self.delayed_set;
+        self.delayed_set = false;
     }
 
     pub fn set_reconciling(&mut self) {
@@ -91,41 +98,44 @@ impl TxReconciliationState {
         self.is_reconciling
     }
 
-    pub fn get_recon_set(&self) -> &HashSet<ShortID> {
-        &self.recon_set
+    pub fn get_recon_set(&self) -> bool {
+        self.recon_set
     }
 
-    pub fn compute_sketch(&mut self, their_txs: Vec<TxId>) -> Sketch {
-        // Given predicting q is hard in a short simulation, we exchange the collection of transactions to be reconciled
-        // between the two parties. Here, q is computed as the difference between the two collections (local and remote)
-        // And a figurative Sketch is created
+    pub fn compute_sketch(&self, they_know_tx: bool) -> Sketch {
+        // q cannot be easily predicted in a short simulation, however it is needed to size the sketch properly.
+        // As a workaround, the sketches exchanges by the simulator are not really sketches, but knowledge of whether
+        // the sender knows the given transaction. q can be scaled down if needed to mimic scenarios where the sketch
+        // exchange is not perfectly efficient
         let local_set = self.get_recon_set();
-        let remote_set = HashSet::from_iter(their_txs);
-        let q = local_set.symmetric_difference(&remote_set).count();
+        let remote_set = they_know_tx;
+        // We can compute the size of the diff as int(A XOR B)
         // TODO: Scale q if required so the predicted difference is not always 100% accurate
-        Sketch::new(local_set.iter().copied().collect_vec(), q)
+        let q = (local_set ^ remote_set) as usize;
+        Sketch::new(local_set, q)
     }
 
-    pub fn compute_sketch_diff(&self, sketch: Sketch) -> (Vec<u32>, Vec<u32>) {
-        let local_set: HashSet<&u32> = HashSet::from_iter(self.get_recon_set());
-        let remote_set = HashSet::from_iter(sketch.get_tx_set());
+    pub fn compute_sketch_diff(&self, sketch: Sketch) -> (bool, bool) {
+        let local_set = self.get_recon_set();
+        let remote_set = sketch.get_tx_set();
 
-        // We care about what we are missing, that's what we send to our peer
-        let our_diff: Vec<u32> = remote_set.difference(&local_set).map(|x| **x).collect_vec();
-        let their_diff = local_set.difference(&remote_set).map(|x| **x).collect_vec();
+        // A XOR B to see if there is a diff
+        let diff = local_set ^ remote_set;
+        // If there us a diff, each end's diff is whether the other end knows the transaction
+        let local_diff = diff && remote_set;
+        let remote_diff = diff && local_set;
 
-        (our_diff, their_diff)
+        (local_diff, remote_diff)
     }
 }
 
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::test::get_random_txid;
 
     impl TxReconciliationState {
-        pub(crate) fn get_delayed_set(&self) -> &HashSet<ShortID> {
-            &self.delayed_set
+        pub(crate) fn get_delayed_set(&self) -> bool {
+            self.delayed_set
         }
     }
 
@@ -134,103 +144,90 @@ mod test {
         let mut tx_recon_state = TxReconciliationState::new(true);
         tx_recon_state.set_reconciling();
         assert!(tx_recon_state.is_reconciling());
-        assert!(tx_recon_state.recon_set.is_empty());
-        assert!(tx_recon_state.delayed_set.is_empty());
+        assert!(!tx_recon_state.recon_set);
+        assert!(!tx_recon_state.delayed_set);
 
-        // Add some txs to the recon set
-        for _ in 0..10 {
-            tx_recon_state.add_tx(get_random_txid());
-        }
+        // Add a transaction to the recon_set
+        tx_recon_state.add_tx();
 
-        // Check that all transactions are delayed
-        assert!(tx_recon_state.recon_set.is_empty());
-        assert!(!tx_recon_state.delayed_set.is_empty());
+        // Check that the transaction has been added to the delayed
+        // set, but the recon set remains empty
+        assert!(!tx_recon_state.recon_set);
+        assert!(tx_recon_state.delayed_set);
+        assert!(tx_recon_state.is_reconciling());
 
         // Move to available and check again
         tx_recon_state.make_delayed_available();
-        assert!(!tx_recon_state.recon_set.is_empty());
-        assert!(tx_recon_state.delayed_set.is_empty());
+        assert!(tx_recon_state.recon_set);
+        assert!(!tx_recon_state.delayed_set);
+        assert!(tx_recon_state.is_reconciling());
 
-        // Add some more transactions to delayed
-        for _ in 0..10 {
-            tx_recon_state.add_tx(get_random_txid());
-        }
-        assert!(!tx_recon_state.recon_set.is_empty());
-        assert!(!tx_recon_state.delayed_set.is_empty());
-
-        let txs = tx_recon_state.get_recon_set().clone();
-        let delayed_txs = tx_recon_state.delayed_set.clone();
-
-        // Clear and  check that the set returned is the one before clearing
-        // that the recon set is empty, but the delayed set is preserved
-        // and that the state is set as not reconciling anymore
-        assert_eq!(tx_recon_state.clear(), txs);
-        assert_eq!(tx_recon_state.delayed_set, delayed_txs);
-        assert!(tx_recon_state.recon_set.is_empty());
-        assert!(!tx_recon_state.delayed_set.is_empty());
+        // Clear, not including delayed (they are only included when cleaning after a simulation)
+        // and check that both sets are empty
+        tx_recon_state.clear(/*include_delayed=*/ false);
+        assert!(!tx_recon_state.recon_set);
+        assert!(!tx_recon_state.delayed_set);
         assert!(!tx_recon_state.is_reconciling());
+
+        // Add again, leave data in delayed and clear
+        tx_recon_state.add_tx();
+        tx_recon_state.clear(/*include_delayed=*/ true);
+        assert!(!tx_recon_state.recon_set);
+        assert!(!tx_recon_state.delayed_set);
+        assert!(!tx_recon_state.is_reconciling());
+
+        // If data is held in recon_set, delayed_set must be empty
+        // so not testing that case
     }
 
     #[test]
     fn test_sketch() {
+        // Start from an empty state
         let mut tx_recon_state = TxReconciliationState::new(true);
-        let mut our_txs = Vec::new();
-        let mut their_txs = Vec::new();
-        let mut unknown_by_us = Vec::new();
-        let mut unknown_by_them = Vec::new();
-        let d = 8;
 
-        // Add some txs to the recon set
-        for i in 0..10 {
-            let txid = get_random_txid();
-            tx_recon_state.recon_set.insert(txid);
-            our_txs.push(txid);
+        // Create their sketch without the transaction. Since none of us know the transaction, the diff size will be 0
+        let mut diff_size = 0;
+        let mut their_sketch = Sketch::new(false, diff_size);
+        assert!(their_sketch.get_size() == diff_size);
 
-            // Make half of the transactions also known by our peer (5)
-            if i % 2 == 0 {
-                their_txs.push(txid);
-            } else {
-                unknown_by_them.push(txid)
-            }
-        }
+        // Compute the diffs and check. None of us know the transaction so the diff should be false
+        let (our_diff, their_diff) = tx_recon_state.compute_sketch_diff(their_sketch);
+        assert!(!our_diff);
+        assert!(!their_diff);
 
-        // Create some transactions (3) unknown by us and add them to their set
-        for _ in 0..3 {
-            let txid = get_random_txid();
-            unknown_by_us.push(txid);
-            their_txs.push(txid);
-        }
+        // Add the tx to the recon set
+        tx_recon_state.add_tx();
+        tx_recon_state.make_delayed_available();
 
-        // Sort the vectors so they can be properly compared later
-        our_txs.sort();
-        their_txs.sort();
-        unknown_by_us.sort();
-        unknown_by_them.sort();
+        // Change their sketch, since now the difference will be 1
+        diff_size = 1;
+        their_sketch = Sketch::new(false, diff_size);
+        assert!(their_sketch.get_size() == diff_size);
 
-        let our_sketch = tx_recon_state.compute_sketch(their_txs.clone());
-        let mut sketch_txs = our_sketch.get_tx_set().clone();
-        sketch_txs.sort();
+        // Compute the diffs and check. We know the tx and they don't, so our diff should be false and theirs should be true
+        let (our_diff, their_diff) = tx_recon_state.compute_sketch_diff(their_sketch);
+        assert!(!our_diff);
+        assert!(their_diff);
 
-        // Check that our sketch contains the transactions we added to it
-        // and that it doesn't contain any of the transactions that only they had
-        assert_eq!(sketch_txs, our_txs);
-        for tx in their_txs.iter() {
-            if unknown_by_us.contains(tx) {
-                assert!(!our_sketch.get_tx_set().contains(tx))
-            }
-        }
-        // The set difference is 8: 5 (they're missing) + 3 (we're missing)
-        assert_eq!(our_sketch.get_size(), d);
+        // Update it so now we don't know but they do
+        tx_recon_state.clear(true);
+        their_sketch = Sketch::new(true, diff_size);
+        assert!(their_sketch.get_size() == diff_size);
 
-        // Compute their sketch and diff them
-        let their_sketch = Sketch {
-            tx_set: their_txs.clone(),
-            d,
-        };
-        let (mut our_diff, mut their_diff) = tx_recon_state.compute_sketch_diff(their_sketch);
-        our_diff.sort();
-        their_diff.sort();
-        assert_eq!(our_diff, unknown_by_us);
-        assert_eq!(their_diff, unknown_by_them);
+        // Compute the diffs and check. They know the transaction and we don't, so out diff should be true and theirs should be false
+        let (our_diff, their_diff) = tx_recon_state.compute_sketch_diff(their_sketch);
+        assert!(our_diff);
+        assert!(!their_diff);
+
+        // Update it so both of us know the transaction
+        diff_size = 0;
+        tx_recon_state.add_tx();
+        tx_recon_state.make_delayed_available();
+        their_sketch = Sketch::new(true, diff_size);
+
+        // Compute the diffs and check. We both know the transaction, so both diff should be false
+        let (our_diff, their_diff) = tx_recon_state.compute_sketch_diff(their_sketch);
+        assert!(!our_diff);
+        assert!(!their_diff);
     }
 }

--- a/hyper-lib/src/txreconciliation.rs
+++ b/hyper-lib/src/txreconciliation.rs
@@ -1,4 +1,4 @@
-use std::collections::HashSet;
+use hashbrown::HashSet;
 
 use itertools::Itertools;
 

--- a/hyperion/src/main.rs
+++ b/hyperion/src/main.rs
@@ -72,7 +72,7 @@ fn main() -> anyhow::Result<()> {
         for e in simulator
             .get_node_mut(source_node_id)
             .unwrap()
-            .broadcast_tx(txid, start_time)
+            .broadcast_tx(start_time)
         {
             simulator.add_event(e);
         }
@@ -125,13 +125,13 @@ fn main() -> anyhow::Result<()> {
                     // This allow us to finish the simulation, for Erlay scenarios, by consuming
                     // all messages in the queue
                     let node = simulator.network.get_node(src).unwrap();
-                    if !node.knows_transaction(&txid)
+                    if !node.knows_transaction()
                         || !node.get_outbounds().keys().all(|node_id| {
                             simulator
                                 .network
                                 .get_node(*node_id)
                                 .unwrap()
-                                .knows_transaction(&txid)
+                                .knows_transaction()
                         })
                     {
                         // Processing an scheduled reconciliation will return the reconciliation flow
@@ -150,7 +150,7 @@ fn main() -> anyhow::Result<()> {
 
         // Make sure every node has received the transaction
         for node in simulator.network.get_nodes() {
-            assert!(node.knows_transaction(&txid));
+            assert!(node.knows_transaction());
         }
 
         // Pick a new txid for the next iteration (if any)
@@ -167,7 +167,7 @@ fn main() -> anyhow::Result<()> {
         overall_time += percentile_time;
 
         for node in simulator.network.get_nodes_mut() {
-            node.reset_timers();
+            node.reset();
         }
     }
 


### PR DESCRIPTION
This PR simplifies the original simulator design in the following ways to allow simulations to run much faster:

- Computes fanout targets just once per transaction, instead of once per peer returning the exact same ordering
- Uses `hashbrown::Hash{map, set}`, which are more performant than the ones on the standard library at the cost of having less DoS resistance, but that is something that should not concern our use case*
- Redesigns the simulator to simulate **a single transaction**. This is the way the simulator was being used anyway, but the data structures and messages supported sending multiple ones. This meant that the events handled by the event queue had to pass around vectors of a single transaction, which was highly inefficient (specially when the underlying `BinaryHeap` had to re-order elements).

\* This may be even more simplified. I think I can get rid of all (or most) maps and replace them with vectors, which should be even more performant

Current results:

| branch  |  fanout sim time | erlay sim time |
| ------------- | ------------- |  ------------- |
| master  | 2.3s | ~8.5s |
|this-branch |~0.8s | ~2.9s|