### PR TITLE
multi: Add option to store results in a csv file

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,8 +51,11 @@ Options:
           Seed to run random activity generator deterministically
       --no-latency
           Don't add network latency to messages exchanges between peers. Useful for debugging
-  -n, --n <N>
+  -n <N>
           Number of times the simulation will be repeated. Smooths the statistical results [default: 1]
+      --output-file <OUTPUT_FILE>
+          The path to an output file where to store simulation results to, in csv.
+          If the file already exists, data will be appended to it, otherwise it will be created [aliases: out]
   -h, --help
           Print help
   -V, --version

--- a/hyper-lib/Cargo.toml
+++ b/hyper-lib/Cargo.toml
@@ -16,4 +16,5 @@ itertools = "0.13.0"
 log = "0.4.20"
 rand = "0.8.5"
 rand_distr = "0.4.3"
+serde = { version = "1.0", features = ["derive"] }
 simple_logger = "5.0.0"

--- a/hyper-lib/src/lib.rs
+++ b/hyper-lib/src/lib.rs
@@ -1,3 +1,9 @@
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use serde::Serialize;
+
+use statistics::NetworkStatistics;
+
 pub mod graph;
 pub mod network;
 pub mod node;
@@ -11,3 +17,113 @@ pub type TxId = u32;
 
 pub const MAX_OUTBOUND_CONNECTIONS: usize = 8;
 static SECS_TO_NANOS: u64 = 1_000_000_000;
+
+pub struct SimulationParameters {
+    /// Number of times the simulation will be repeated. Smooths the statistical results
+    pub n: u32,
+    /// The number of reachable nodes in the simulated network
+    pub reachable: usize,
+    /// The number of unreachable nodes in the simulated network
+    pub unreachable: usize,
+    /// Whether or not nodes in the simulation support Erlay (all of them for now)
+    pub erlay: bool,
+}
+
+impl SimulationParameters {
+    pub fn new(n: u32, reachable: usize, unreachable: usize, erlay: bool) -> Self {
+        SimulationParameters {
+            n,
+            reachable,
+            unreachable,
+            erlay,
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct OutputResult {
+    timestamp: u64,
+    percentile_target: u16,
+    percentile_time: u64,
+    #[serde(rename = "r-sent-msgs")]
+    reachable_sent_msgs: f32,
+    #[serde(rename = "r-received-msgs")]
+    reachable_received_msgs: f32,
+    #[serde(rename = "r-sent-bytes")]
+    reachable_sent_bytes: f32,
+    #[serde(rename = "r-received-bytes")]
+    reachable_received_bytes: f32,
+    #[serde(rename = "u-sent-msgs")]
+    unreachable_sent_msgs: f32,
+    #[serde(rename = "u-received-msgs")]
+    unreachable_received_msgs: f32,
+    #[serde(rename = "u-sent-bytes")]
+    unreachable_sent_bytes: f32,
+    #[serde(rename = "u-received-bytes")]
+    unreachable_received_bytes: f32,
+    #[serde(rename = "r")]
+    reachable_count: usize,
+    #[serde(rename = "u")]
+    unreachable_count: usize,
+    n: u32,
+    erlay: bool,
+    seed: u64,
+}
+
+impl OutputResult {
+    pub fn new(
+        percentile_target: u16,
+        percentile_time: u64,
+        statistics: NetworkStatistics,
+        sim_params: SimulationParameters,
+        seed: u64,
+    ) -> Self {
+        let n_float = sim_params.n as f32;
+        let avg_msgs = statistics.avg_messages();
+        let avg_bytes = statistics.avg_bytes();
+        OutputResult {
+            timestamp: SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_secs(),
+            percentile_time,
+            percentile_target,
+            reachable_sent_msgs: avg_msgs.sent_reachable() / n_float,
+            reachable_received_msgs: avg_msgs.received_reachable() / n_float,
+            reachable_sent_bytes: avg_bytes.sent_reachable() / n_float,
+            reachable_received_bytes: avg_bytes.received_reachable() / n_float,
+            unreachable_sent_msgs: avg_msgs.sent_unreachable() / n_float,
+            unreachable_received_msgs: avg_msgs.received_unreachable() / n_float,
+            unreachable_sent_bytes: avg_bytes.sent_unreachable() / n_float,
+            unreachable_received_bytes: avg_bytes.received_unreachable() / n_float,
+            n: sim_params.n,
+            reachable_count: sim_params.reachable,
+            unreachable_count: sim_params.unreachable,
+            erlay: sim_params.erlay,
+            seed,
+        }
+    }
+
+    pub fn display(&self) {
+        log::info!(
+            "Transaction reached {}% of nodes in the network in {}s",
+            self.percentile_target,
+            Duration::from_nanos(self.percentile_time).as_secs_f32()
+        );
+        log::info!(
+            "Reachable nodes sent/received {}/{} messages ({}/{} bytes) (avg)",
+            self.reachable_sent_msgs,
+            self.reachable_received_msgs,
+            self.reachable_sent_bytes,
+            self.reachable_received_bytes
+        );
+        log::info!(
+            "Unreachable nodes sent/received {}/{} messages ({}/{} bytes) (avg)",
+            self.unreachable_sent_msgs,
+            self.unreachable_received_msgs,
+            self.unreachable_sent_bytes,
+            self.unreachable_received_bytes
+        );
+    }
+}

--- a/hyper-lib/src/simulator.rs
+++ b/hyper-lib/src/simulator.rs
@@ -116,18 +116,16 @@ impl Simulator {
         unreachable_count: usize,
         outbounds_count: usize,
         is_erlay: bool,
-        seed: Option<u64>,
+        seed: &mut Option<u64>,
         network_latency: bool,
     ) -> Self {
-        let seed = if let Some(seed) = seed {
-            log::info!("Using user provided rng seed: {}", seed);
-            seed
+        if let Some(s) = seed {
+            log::info!("Using user provided rng seed: {}", s);
         } else {
-            let s = thread_rng().next_u64();
-            log::info!("Using fresh rng seed: {}", s);
-            s
+            *seed = Some(thread_rng().next_u64());
+            log::info!("Using fresh rng seed: {}", seed.unwrap());
         };
-        let mut rng: StdRng = StdRng::seed_from_u64(seed);
+        let mut rng: StdRng = StdRng::seed_from_u64(seed.unwrap());
         let network = Network::new(
             reachable_count,
             unreachable_count,

--- a/hyperion/Cargo.toml
+++ b/hyperion/Cargo.toml
@@ -13,6 +13,8 @@ hyper-lib = { path = "../hyper-lib" }
 
 anyhow = { version = "1.0.69", features = ["backtrace"] }
 clap = { version = "4.1.6", features = ["derive", "std", "help", "usage", "error-context"], default-features = false }
+csv = "1.3.1"
+home = "0.5.9"
 indicatif = "0.17.8"
 log = "0.4.20"
 simple_logger = "5.0.0"

--- a/hyperion/src/cli.rs
+++ b/hyperion/src/cli.rs
@@ -1,6 +1,7 @@
 use clap::Parser;
-use hyper_lib::MAX_OUTBOUND_CONNECTIONS;
 use log::LevelFilter;
+
+use hyper_lib::{SimulationParameters, MAX_OUTBOUND_CONNECTIONS};
 
 /// Default number of unreachable nodes in the simulated network.
 const UNREACHABLE_NODE_COUNT: usize = 100000;
@@ -40,6 +41,10 @@ pub struct Cli {
     /// Number of times the simulation will be repeated. Smooths the statistical results
     #[clap(short, default_value_t = 1)]
     pub n: u32,
+    /// An output file name where to store simulation results to, in csv.
+    /// If the file already exists, data will be appended to it, otherwise it will be created
+    #[clap(long, visible_alias = "out", verbatim_doc_comment)]
+    pub output_file: Option<String>,
 }
 
 impl Cli {
@@ -47,5 +52,9 @@ impl Cli {
         assert!(self.reachable >= 10 * self.outbounds,
             "Too few reachable peers. In order to allow enough randomness in the network topology generation, please make sure
             the number of reachable nodes is, at least, 10 times the number of outbound connections per node");
+    }
+
+    pub fn get_simulation_params(&self) -> SimulationParameters {
+        SimulationParameters::new(self.n, self.reachable, self.unreachable, self.erlay)
     }
 }


### PR DESCRIPTION
Adds the option to store the simulation results in a csv so simulations can be easily automated without.

Data is stored in CSV with a header to a given output file. If the output file already exists, the  right format and header are assumed, so data is simply appended