### PR TITLE
sim: Removes missed (and useless) instances of txid

### DIFF
--- a/hyper-lib/src/lib.rs
+++ b/hyper-lib/src/lib.rs
@@ -13,8 +13,6 @@ pub mod txreconciliation;
 
 mod indexedmap;
 
-pub type TxId = u32;
-
 pub const MAX_OUTBOUND_CONNECTIONS: usize = 8;
 static SECS_TO_NANOS: u64 = 1_000_000_000;
 

--- a/hyper-lib/src/simulator.rs
+++ b/hyper-lib/src/simulator.rs
@@ -7,7 +7,7 @@ use rand::{thread_rng, Rng, RngCore, SeedableRng};
 
 use crate::network::{Link, Network, NetworkMessage};
 use crate::node::{Node, NodeId, RECON_REQUEST_INTERVAL};
-use crate::{TxId, SECS_TO_NANOS};
+use crate::SECS_TO_NANOS;
 
 /// An enumeration of all the events that can be created in a simulation
 #[derive(Clone, Hash, Eq, PartialEq, Debug)]
@@ -187,10 +187,6 @@ impl Simulator {
     pub fn get_next_event_time(&mut self) -> Option<u64> {
         let scheduled_event = self.event_queue.peek()?;
         Some(scheduled_event.time())
-    }
-
-    pub fn get_random_txid(&mut self) -> TxId {
-        self.rng.next_u32()
     }
 
     pub fn get_random_nodeid(&mut self) -> NodeId {


### PR DESCRIPTION
These are remnants of #25

Keeping track of the txid for multi runs to make sure `get_fanout_targets` does not return the same values as for a previous simulation is not necessary anymore. Furthermore, `ProcessDelayedRequest` was mistakenly pattern matches with a txid, when it is actually composed as `(NodeId, NodeId)`.