### PR TITLE
multi: Enables general purpose graph functionality

### DIFF
--- a/hyper-lib/Cargo.toml
+++ b/hyper-lib/Cargo.toml
@@ -13,6 +13,7 @@ graphrs = {version = "0.9.0", optional = true }
 hashbrown = "0.15"
 itertools = "0.13.0"
 log = "0.4.20"
+quick-xml = "0.37.1"
 rand = "0.8.5"
 rand_distr = "0.4.3"
 serde = { version = "1.0", features = ["derive"] }

--- a/hyper-lib/Cargo.toml
+++ b/hyper-lib/Cargo.toml
@@ -9,8 +9,7 @@ Supporting library for hyperion: a discrete time network event simulator for Bit
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-# FIXME: Move this into a feature
-graphrs = "0.9.0"
+graphrs = {version = "0.9.0", optional = true }
 hashbrown = "0.15"
 itertools = "0.13.0"
 log = "0.4.20"
@@ -18,3 +17,6 @@ rand = "0.8.5"
 rand_distr = "0.4.3"
 serde = { version = "1.0", features = ["derive"] }
 simple_logger = "5.0.0"
+
+[features]
+graph = ["dep:graphrs"]

--- a/hyper-lib/src/graph.rs
+++ b/hyper-lib/src/graph.rs
@@ -2,12 +2,12 @@ use std::fmt::Display;
 use std::hash::Hash;
 use std::sync::{Arc, Mutex};
 
-use graphrs::{Graph, GraphSpecs};
 use hashbrown::HashMap;
 use rand::rngs::StdRng;
 
 use crate::network::{Link, Network};
 use crate::node::{Node, NodeId};
+use crate::parse_graph::{Graph, NodeData};
 
 #[derive(Clone)]
 pub struct NodeAttributes {
@@ -15,7 +15,7 @@ pub struct NodeAttributes {
     is_erlay: bool,
 }
 
-impl TryFrom<&Network> for Graph<NodeId, NodeAttributes> {
+impl TryFrom<&Network> for Graph {
     type Error = graphrs::Error;
 
     fn try_from(network: &Network) -> Result<Self, Self::Error> {
@@ -23,48 +23,46 @@ impl TryFrom<&Network> for Graph<NodeId, NodeAttributes> {
         for node in network.get_nodes() {
             for out_peer_id in node.get_outbounds().keys() {
                 let link: Link = (node.get_id(), *out_peer_id).into();
-                edges.push(graphrs::Edge::with_weight(
-                    node.get_id(),
-                    *out_peer_id,
-                    *network.get_links().get(&link).unwrap() as f64,
+                edges.push((
+                    node.get_id().to_string(),
+                    out_peer_id.to_string(),
+                    *network.get_links().get(&link).unwrap(),
                 ))
             }
         }
 
-        Graph::<NodeId, NodeAttributes>::new_from_nodes_and_edges(
-            network
-                .get_nodes()
-                .iter()
-                .map(|node| {
-                    graphrs::Node::from_name_and_attributes(
-                        node.get_id(),
-                        NodeAttributes {
-                            is_reachable: node.is_reachable(),
-                            is_erlay: node.is_erlay(),
-                        },
-                    )
-                })
-                .collect::<Vec<graphrs::Node<NodeId, NodeAttributes>>>(),
-            edges,
-            GraphSpecs::directed(),
-        )
+        let mut nodes = network
+            .get_nodes()
+            .iter()
+            .map(|node| {
+                NodeData::new(
+                    node.get_id().to_string(),
+                    HashMap::from([
+                        ("is_reachable".to_string(), node.is_reachable().to_string()),
+                        ("is_erlay".to_string(), node.is_erlay().to_string()),
+                    ]),
+                )
+            })
+            .collect::<Vec<_>>();
+
+        Ok(Graph::new(nodes, edges))
     }
 }
 
-impl From<(Graph<NodeId, NodeAttributes>, Arc<Mutex<StdRng>>)> for Network {
-    fn from(value: (Graph<NodeId, NodeAttributes>, Arc<Mutex<StdRng>>)) -> Self {
+impl From<(Graph, Arc<Mutex<StdRng>>)> for Network {
+    fn from(value: (Graph, Arc<Mutex<StdRng>>)) -> Self {
         let graph = value.0;
         let rng = value.1;
 
         let mut nodes = graph
-            .get_all_nodes()
+            .get_nodes()
             .into_iter()
             .map(|n| {
                 Node::new(
-                    n.name,
+                    n.get_id(),
                     rng.clone(),
-                    n.attributes.as_ref().unwrap().is_reachable,
-                    n.attributes.as_ref().unwrap().is_erlay,
+                    n.get_attributes().get("is_reachable").unwrap(),
+                    n.get_attributes().get("is_erlay").unwrap(),
                 )
             })
             .collect::<Vec<_>>();
@@ -74,29 +72,29 @@ impl From<(Graph<NodeId, NodeAttributes>, Arc<Mutex<StdRng>>)> for Network {
 
         // Create all connections
         let mut links = HashMap::new();
-        for edge in graph.get_all_edges().iter() {
+        for (src_id, dst_id, latency) in graph.get_edges().iter() {
             {
-                let src = nodes.get_mut(edge.u).unwrap();
-                src.connect(edge.v, src.is_erlay());
+                let src = nodes.get_mut(src_id).unwrap();
+                src.connect(dst_id, src.is_erlay());
             }
             {
-                let dst = nodes.get_mut(edge.v).unwrap();
-                dst.accept_connection(edge.u, dst.is_erlay());
+                let dst = nodes.get_mut(dst_id).unwrap();
+                dst.accept_connection(src_id, dst.is_erlay());
             }
-            links.insert((edge.u, edge.v).into(), edge.weight as u64);
+            links.insert((src_id, dst_id).into(), weight as u64);
         }
 
         Network::from_connected_nodes_and_links(nodes, links)
     }
 }
 
-pub fn save_graph<T, A>(graph: &Graph<T, A>, filename: &str) -> Result<(), std::io::Error>
-where
-    T: Eq + Clone + PartialOrd + Ord + Hash + Send + Sync + Display,
-    A: Clone,
-{
-    graphrs::readwrite::graphml::write_graphml(graph, filename)
-}
+// pub fn save_graph<T, A>(graph: &Graph<T, A>, filename: &str) -> Result<(), std::io::Error>
+// where
+//     T: Eq + Clone + PartialOrd + Ord + Hash + Send + Sync + Display,
+//     A: Clone,
+// {
+//     graphrs::readwrite::graphml::write_graphml(graph, filename)
+// }
 
 // WIP: Turns out you cannot load into Graph<T, A> because the attributes are actually never backed up SMH
 // Find another graph lib...

--- a/hyper-lib/src/graph.rs
+++ b/hyper-lib/src/graph.rs
@@ -1,39 +1,107 @@
 use std::fmt::Display;
 use std::hash::Hash;
+use std::sync::{Arc, Mutex};
 
-use graphrs::{Error, Graph, GraphSpecs};
+use graphrs::{Graph, GraphSpecs};
+use hashbrown::HashMap;
+use rand::rngs::StdRng;
 
+use crate::network::{Link, Network};
 use crate::node::{Node, NodeId};
 
-pub fn build_grap(
-    reachable_nodes: &[Node],
-    unreachable_nodes: &[Node],
-) -> Result<Graph<NodeId, ()>, Error> {
-    let nodes = [unreachable_nodes, reachable_nodes]
-        .concat()
-        .iter()
-        .map(|node| graphrs::Node::from_name(node.get_id()))
-        .collect::<Vec<graphrs::Node<NodeId, ()>>>();
-
-    let mut edges = Vec::new();
-    for node in reachable_nodes.iter() {
-        for out_peer_id in node.get_outbounds().keys() {
-            edges.push(graphrs::Edge::new(node.get_id(), *out_peer_id))
-        }
-    }
-    for node in unreachable_nodes.iter() {
-        for out_peer_id in node.get_outbounds().keys() {
-            edges.push(graphrs::Edge::new(node.get_id(), *out_peer_id))
-        }
-    }
-
-    Graph::<NodeId, ()>::new_from_nodes_and_edges(nodes, edges, GraphSpecs::directed())
+#[derive(Clone)]
+pub struct NodeAttributes {
+    is_reachable: bool,
+    is_erlay: bool,
 }
 
-pub fn save_graph<T, A>(graph: Graph<T, A>, filename: &str) -> Result<(), std::io::Error>
+impl TryFrom<&Network> for Graph<NodeId, NodeAttributes> {
+    type Error = graphrs::Error;
+
+    fn try_from(network: &Network) -> Result<Self, Self::Error> {
+        let mut edges = Vec::new();
+        for node in network.get_nodes() {
+            for out_peer_id in node.get_outbounds().keys() {
+                let link: Link = (node.get_id(), *out_peer_id).into();
+                edges.push(graphrs::Edge::with_weight(
+                    node.get_id(),
+                    *out_peer_id,
+                    *network.get_links().get(&link).unwrap() as f64,
+                ))
+            }
+        }
+
+        Graph::<NodeId, NodeAttributes>::new_from_nodes_and_edges(
+            network
+                .get_nodes()
+                .iter()
+                .map(|node| {
+                    graphrs::Node::from_name_and_attributes(
+                        node.get_id(),
+                        NodeAttributes {
+                            is_reachable: node.is_reachable(),
+                            is_erlay: node.is_erlay(),
+                        },
+                    )
+                })
+                .collect::<Vec<graphrs::Node<NodeId, NodeAttributes>>>(),
+            edges,
+            GraphSpecs::directed(),
+        )
+    }
+}
+
+impl From<(Graph<NodeId, NodeAttributes>, Arc<Mutex<StdRng>>)> for Network {
+    fn from(value: (Graph<NodeId, NodeAttributes>, Arc<Mutex<StdRng>>)) -> Self {
+        let graph = value.0;
+        let rng = value.1;
+
+        let mut nodes = graph
+            .get_all_nodes()
+            .into_iter()
+            .map(|n| {
+                Node::new(
+                    n.name,
+                    rng.clone(),
+                    n.attributes.as_ref().unwrap().is_reachable,
+                    n.attributes.as_ref().unwrap().is_erlay,
+                )
+            })
+            .collect::<Vec<_>>();
+
+        // Sort the vector in ascending order so we can get nodes by position using their node_id
+        nodes.sort_by_key(|a| a.get_id());
+
+        // Create all connections
+        let mut links = HashMap::new();
+        for edge in graph.get_all_edges().iter() {
+            {
+                let src = nodes.get_mut(edge.u).unwrap();
+                src.connect(edge.v, src.is_erlay());
+            }
+            {
+                let dst = nodes.get_mut(edge.v).unwrap();
+                dst.accept_connection(edge.u, dst.is_erlay());
+            }
+            links.insert((edge.u, edge.v).into(), edge.weight as u64);
+        }
+
+        Network::from_connected_nodes_and_links(nodes, links)
+    }
+}
+
+pub fn save_graph<T, A>(graph: &Graph<T, A>, filename: &str) -> Result<(), std::io::Error>
 where
     T: Eq + Clone + PartialOrd + Ord + Hash + Send + Sync + Display,
     A: Clone,
 {
-    graphrs::readwrite::graphml::write_graphml(&graph, filename)
+    graphrs::readwrite::graphml::write_graphml(graph, filename)
 }
+
+// WIP: Turns out you cannot load into Graph<T, A> because the attributes are actually never backed up SMH
+// Find another graph lib...
+// pub fn load_graph(filename: &str) -> Result<Graph<String, ()>, graphrs::Error> {
+//     let g = graphrs::readwrite::graphml::read_graphml(filename, GraphSpecs::directed());
+//     log::info!("{:?}", g.unwrap().get_all_nodes());
+//     graphrs::readwrite::graphml::read_graphml(filename, GraphSpecs::directed())
+// }

--- a/hyper-lib/src/lib.rs
+++ b/hyper-lib/src/lib.rs
@@ -4,6 +4,7 @@ use serde::Serialize;
 
 use statistics::NetworkStatistics;
 
+#[cfg(feature = "graph")]
 pub mod graph;
 pub mod network;
 pub mod node;

--- a/hyper-lib/src/lib.rs
+++ b/hyper-lib/src/lib.rs
@@ -8,6 +8,7 @@ use statistics::NetworkStatistics;
 pub mod graph;
 pub mod network;
 pub mod node;
+pub mod parse_graph;
 pub mod simulator;
 pub mod statistics;
 pub mod txreconciliation;

--- a/hyper-lib/src/node.rs
+++ b/hyper-lib/src/node.rs
@@ -184,6 +184,16 @@ impl Node {
         }
     }
 
+    /// Whether the node is reachable or not
+    pub fn is_reachable(&self) -> bool {
+        self.is_reachable
+    }
+
+    /// Whether the node is erlay or not
+    pub fn is_erlay(&self) -> bool {
+        self.is_erlay
+    }
+
     // Resets the node state so a new round of the simulation can be run from a clean state
     pub fn reset(&mut self) {
         self.inbounds_poisson_timer.next_interval = 0;

--- a/hyper-lib/src/parse_graph.rs
+++ b/hyper-lib/src/parse_graph.rs
@@ -1,0 +1,229 @@
+use hashbrown::{HashMap, HashSet};
+use quick_xml::events::{attributes, BytesEnd, BytesStart, BytesText, Event};
+use quick_xml::{Reader, Writer};
+
+use std::fs::File;
+use std::io::BufReader;
+use std::io::BufWriter;
+
+pub struct Graph {
+    nodes: Vec<NodeData>,
+    edges: Vec<(String, String, u64)>,
+}
+
+impl Graph {
+    pub fn new(nodes: Vec<NodeData>, edges: Vec<(String, String, u64)>) -> Self {
+        Self { nodes, edges }
+    }
+
+    pub fn get_nodes(&self) -> &Vec<NodeData> {
+        &self.nodes
+    }
+
+    pub fn get_edges(&self) -> &Vec<(String, String, u64)> {
+        &self.edges
+    }
+}
+
+#[derive(Debug)]
+pub struct NodeData {
+    id: String,
+    attributes: HashMap<String, String>,
+}
+
+impl NodeData {
+    pub fn new(id: String, attributes: HashMap<String, String>) -> Self {
+        Self { id, attributes }
+    }
+
+    pub fn get_id(&self) -> &String {
+        &self.id
+    }
+
+    pub fn get_attributes(&self) -> &HashMap<String, String> {
+        &self.attributes
+    }
+}
+
+/// Helper function to extract an attribute from an XML element.
+fn get_attribute<'a>(element: &'a BytesStart, name: &[u8]) -> Option<String> {
+    element
+        .attributes()
+        .filter_map(|attr| attr.ok())
+        .find(|attr| attr.key.as_ref() == name)
+        .map(|attr| String::from_utf8_lossy(&attr.value).to_string())
+}
+
+fn parse_graphml(
+    file_path: &str,
+) -> Result<(Vec<NodeData>, Vec<(String, String, u64)>), Box<dyn std::error::Error>> {
+    // Open and read the GraphML file
+    let file = File::open(file_path)?;
+    let reader = BufReader::new(file);
+    let mut xml_reader = Reader::from_reader(reader);
+    xml_reader.config_mut().trim_text(true);
+
+    // Graph structure to build
+    let mut nodes = Vec::new();
+    let mut edges = Vec::new();
+
+    // Parsing state
+    let mut buf = Vec::new();
+    let mut current_node_id: Option<String> = None;
+    let mut parsed_nodes: HashSet<String> = HashSet::new();
+    let mut current_node_attributes: HashMap<String, String> = HashMap::new();
+    let mut current_edge_source: Option<String> = None;
+    let mut current_edge_target: Option<String> = None;
+    let mut current_edge_weight: Option<f32> = None;
+
+    loop {
+        match xml_reader.read_event_into(&mut buf) {
+            Ok(Event::Start(ref e)) => match e.name().as_ref() {
+                b"node" => {
+                    // Start parsing a node
+                    if let Some(id) = get_attribute(e, b"id") {
+                        current_node_id = Some(id);
+                    }
+                }
+                b"edge" => {
+                    // Start parsing an edge
+                    current_edge_source = get_attribute(e, b"source");
+                    current_edge_target = get_attribute(e, b"target");
+                }
+                b"data" => {
+                    // Parse attributes for the current node or edge
+                    if let Some(key) = get_attribute(e, b"key") {
+                        if let Ok(Event::Text(text)) = xml_reader.read_event_into(&mut buf) {
+                            let value = text.unescape().unwrap_or_default().to_string();
+                            if current_node_id.is_some() {
+                                // Node attributes
+                                current_node_attributes.insert(key, value);
+                            } else if current_edge_source.is_some() && key == "weight" {
+                                // Edge weight
+                                current_edge_weight = value.parse().ok();
+                            }
+                        }
+                    }
+                }
+                _ => {}
+            },
+            Ok(Event::End(ref e)) => match e.name().as_ref() {
+                b"node" => {
+                    // Finish parsing a node
+                    if let Some(node_id) = current_node_id.take() {
+                        if parsed_nodes.contains(&node_id) {
+                            return Err(Box::new(std::io::Error::new(
+                                std::io::ErrorKind::AlreadyExists,
+                                "Duplicated node found while parsing file",
+                            )));
+                        } else {
+                            nodes.push(NodeData {
+                                id: node_id.clone(),
+                                attributes: current_node_attributes.drain().collect(),
+                            });
+                            parsed_nodes.insert(node_id);
+                        }
+                    }
+                }
+                b"edge" => {
+                    // Finish parsing an edge
+                    if let (Some(source), Some(target)) =
+                        (current_edge_source.take(), current_edge_target.take())
+                    {
+                        // Weights for our graphs represent latency **in nanoseconds** so no floating point
+                        edges.push((source, target, current_edge_weight.unwrap_or(0.0) as u64));
+                        current_edge_weight = None;
+                    }
+                }
+                _ => {}
+            },
+            Ok(Event::Eof) => break, // End of file
+            Err(e) => return Err(Box::new(e)),
+            _ => {}
+        }
+        buf.clear();
+    }
+
+    Ok((nodes, edges))
+}
+
+fn write_graphml(
+    nodes: Vec<NodeData>,
+    edges: Vec<(String, String, u64)>,
+    file_path: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
+    // Open the file for writing
+    let file = File::create(file_path)?;
+    let writer = BufWriter::new(file);
+    let mut xml_writer = Writer::new(writer);
+
+    // Start the GraphML document
+    xml_writer.write_event(Event::Start(BytesStart::new("graphml")))?;
+
+    // Add keys for attributes
+    // If node or edge attributes are consistent, keys can be written dynamically
+    let mut attribute_keys: HashSet<String> = HashSet::new();
+    for node in &nodes {
+        for key in node.attributes.keys() {
+            attribute_keys.insert(key.clone());
+        }
+    }
+
+    for key in attribute_keys {
+        let mut key_element = BytesStart::new("key");
+        key_element.push_attribute(("id", key.as_str()));
+        key_element.push_attribute(("for", "node"));
+        key_element.push_attribute(("attr.name", key.as_str()));
+        key_element.push_attribute(("attr.type", "string"));
+        xml_writer.write_event(Event::Empty(key_element))?;
+    }
+
+    // Start the graph element
+    let mut graph_element = BytesStart::new("graph");
+    graph_element.push_attribute(("id", "G"));
+    graph_element.push_attribute(("edgedefault", "directed"));
+    xml_writer.write_event(Event::Start(graph_element))?;
+
+    // Write nodes
+    for node in nodes {
+        let mut node_element = BytesStart::new("node");
+        node_element.push_attribute(("id", node.id.as_str()));
+        xml_writer.write_event(Event::Start(node_element))?;
+
+        // Write node attributes
+        for (key, value) in node.attributes {
+            let mut data_element = BytesStart::new("data");
+            data_element.push_attribute(("key", key.as_str()));
+            xml_writer.write_event(Event::Start(data_element))?;
+            xml_writer.write_event(Event::Text(BytesText::new(value.as_str())))?;
+            xml_writer.write_event(Event::End(BytesEnd::new("data")))?;
+        }
+
+        xml_writer.write_event(Event::End(BytesEnd::new("node")))?;
+    }
+
+    // Write edges
+    for (source, target, weight) in edges {
+        let mut edge_element = BytesStart::new("edge");
+        edge_element.push_attribute(("source", source.as_str()));
+        edge_element.push_attribute(("target", target.as_str()));
+        xml_writer.write_event(Event::Start(edge_element))?;
+
+        // Write edge weight
+        let mut data_element = BytesStart::new("data");
+        data_element.push_attribute(("key", "weight"));
+        xml_writer.write_event(Event::Start(data_element))?;
+        xml_writer.write_event(Event::Text(BytesText::new(weight.to_string().as_str())))?;
+        xml_writer.write_event(Event::End(BytesEnd::new("data")))?;
+
+        xml_writer.write_event(Event::End(BytesEnd::new("edge")))?;
+    }
+
+    // End the graph element
+    xml_writer.write_event(Event::End(BytesEnd::new("graph")))?;
+
+    // End the GraphML document
+    xml_writer.write_event(Event::End(BytesEnd::new("graphml")))?;
+
+    Ok(())
+}

--- a/hyper-lib/src/simulator.rs
+++ b/hyper-lib/src/simulator.rs
@@ -147,23 +147,23 @@ impl Simulator {
         }
     }
 
-    // Creates a simulator from a given [Network]. Useful when creating simulations using the graph feature
-    #[cfg(feature = "graph")]
-    pub fn from_graph(graph: Graph<NodeId, NodeAttributes>, seed: &mut Option<u64>) -> Self {
-        if let Some(s) = seed {
-            log::info!("Using user provided rng seed: {}", s);
-        } else {
-            *seed = Some(thread_rng().next_u64());
-            log::info!("Using fresh rng seed: {}", seed.unwrap());
-        };
+    // // Creates a simulator from a given [Network]. Useful when creating simulations using the graph feature
+    // #[cfg(feature = "graph")]
+    // pub fn from_graph(graph: Graph<NodeId, NodeAttributes>, seed: &mut Option<u64>) -> Self {
+    //     if let Some(s) = seed {
+    //         log::info!("Using user provided rng seed: {}", s);
+    //     } else {
+    //         *seed = Some(thread_rng().next_u64());
+    //         log::info!("Using fresh rng seed: {}", seed.unwrap());
+    //     };
 
-        let rng = Arc::new(Mutex::new(StdRng::seed_from_u64(seed.unwrap())));
-        Self {
-            rng: rng.clone(),
-            network: (graph, rng.clone()).into(),
-            event_queue: BinaryHeap::new(),
-        }
-    }
+    //     let rng = Arc::new(Mutex::new(StdRng::seed_from_u64(seed.unwrap())));
+    //     Self {
+    //         rng: rng.clone(),
+    //         network: (graph, rng.clone()).into(),
+    //         event_queue: BinaryHeap::new(),
+    //     }
+    // }
 
     pub fn schedule_set_reconciliation(&mut self, current_time: u64) {
         if self.network.is_erlay() {

--- a/hyper-lib/src/simulator.rs
+++ b/hyper-lib/src/simulator.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "graph")]
+use graphrs::Graph;
 use std::cmp::{Ordering, Reverse};
 use std::collections::BinaryHeap;
 use std::hash::Hash;
@@ -6,6 +8,8 @@ use std::sync::{Arc, Mutex};
 use rand::rngs::StdRng;
 use rand::{thread_rng, Rng, RngCore, SeedableRng};
 
+#[cfg(feature = "graph")]
+use crate::graph::NodeAttributes;
 use crate::network::{Link, Network, NetworkMessage};
 use crate::node::{Node, NodeId, RECON_REQUEST_INTERVAL};
 use crate::SECS_TO_NANOS;
@@ -143,6 +147,24 @@ impl Simulator {
         }
     }
 
+    // Creates a simulator from a given [Network]. Useful when creating simulations using the graph feature
+    #[cfg(feature = "graph")]
+    pub fn from_graph(graph: Graph<NodeId, NodeAttributes>, seed: &mut Option<u64>) -> Self {
+        if let Some(s) = seed {
+            log::info!("Using user provided rng seed: {}", s);
+        } else {
+            *seed = Some(thread_rng().next_u64());
+            log::info!("Using fresh rng seed: {}", seed.unwrap());
+        };
+
+        let rng = Arc::new(Mutex::new(StdRng::seed_from_u64(seed.unwrap())));
+        Self {
+            rng: rng.clone(),
+            network: (graph, rng.clone()).into(),
+            event_queue: BinaryHeap::new(),
+        }
+    }
+
     pub fn schedule_set_reconciliation(&mut self, current_time: u64) {
         if self.network.is_erlay() {
             for node in self.network.get_nodes_mut() {
@@ -166,16 +188,17 @@ impl Simulator {
     /// These latencies simulate the messages traveling across the network
     pub fn add_event(&mut self, mut scheduled_event: ScheduledEvent) {
         let event = &scheduled_event.inner;
-        if event.is_receive_message() && self.network.has_latency() {
-            let link = &event.get_link().unwrap();
-            let latency = *self.network.get_links().get(link).unwrap_or_else(|| {
-                panic!(
-                    "No connection found between node: {} and node {}",
-                    link.a(),
-                    link.b(),
-                )
-            });
-            scheduled_event.time.0 += latency;
+        if event.is_receive_message() {
+            if let Some(link) = event.get_link() {
+                let latency = *self.network.get_links().get(&link).unwrap_or_else(|| {
+                    panic!(
+                        "No connection found between node: {} and node {}",
+                        link.a(),
+                        link.b(),
+                    )
+                });
+                scheduled_event.time.0 += latency;
+            }
         }
 
         self.event_queue.push(scheduled_event);

--- a/hyperion/Cargo.toml
+++ b/hyperion/Cargo.toml
@@ -18,3 +18,6 @@ home = "0.5.9"
 indicatif = "0.17.8"
 log = "0.4.20"
 simple_logger = "5.0.0"
+
+[features]
+serde = ["hyper-lib/graph"]


### PR DESCRIPTION
Enables loading graph from files to run simulations, and backing up networks as graphs for visualization / re-running experiments

This is currently unfinished given `graphrs` does not allow loading and storing graphs using the same format. Nodes attributes are actually never backed up, so they cannot be loaded.

I've been looking into other libraries but none really have a good support for import/export using a widely used format, as far as I could tell.

It should be relatively easy to finish this by writing a custom XML import/export using something like `quick-xml`, but I don't think this is currently a priority