### PR TITLE
lib: Change transaction size to something reasonable

### DIFF
--- a/hyper-lib/src/network.rs
+++ b/hyper-lib/src/network.rs
@@ -89,8 +89,9 @@ impl NetworkMessage {
             NetworkMessage::INV => 36,
             // Type of entry + hash (4+32 bytes) * number of entries
             NetworkMessage::GETDATA => 36,
-            // Each node will receive the transaction exactly once, we can count this as zero
-            NetworkMessage::TX => 0,
+            // Each node will receive the transaction exactly once. The exact value here doesn't matter much, as long as it is within
+            // a reasonable size for a transaction. If made to small, it could be mistaken as other messages, like INVs
+            NetworkMessage::TX => 192,
             // Not counting the size of periodic requests, check the previous comment for rationale
             NetworkMessage::REQRECON(_) => 0,
             // The sketch size is based on the expected difference of the sets, 4-bytes per count

--- a/hyper-lib/src/statistics.rs
+++ b/hyper-lib/src/statistics.rs
@@ -195,6 +195,22 @@ impl NodeStatistics {
     pub fn get_received_from_inbounds_bytes(&self) -> u64 {
         self.bytes.from_inbounds
     }
+
+    pub fn get_tx_sent_to_inbounds(&self) -> u64 {
+        self.tx.to_inbounds
+    }
+
+    pub fn get_tx_sent_to_outbounds(&self) -> u64 {
+        self.tx.to_outbounds
+    }
+
+    pub fn get_tx_received_from_inbounds(&self) -> u64 {
+        self.tx.from_inbounds
+    }
+
+    pub fn get_tx_received_from_outbounds(&self) -> u64 {
+        self.tx.from_outbounds
+    }
 }
 
 impl Default for NodeStatistics {
@@ -299,6 +315,32 @@ impl NetworkStatistics {
             sent_unreachable: self.unreachable_stats.get_sent_bytes() as f32
                 / self.unreachable_count as f32,
             received_unreachable: self.unreachable_stats.get_received_bytes() as f32
+                / self.unreachable_count as f32,
+        }
+    }
+
+    pub fn avg_tx_inbounds(&self) -> AveragedStatistics {
+        AveragedStatistics {
+            sent_reachable: self.reachable_stats.get_tx_sent_to_inbounds() as f32
+                / self.reachable_count as f32,
+            received_reachable: self.reachable_stats.get_tx_received_from_inbounds() as f32
+                / self.reachable_count as f32,
+            sent_unreachable: self.unreachable_stats.get_tx_sent_to_inbounds() as f32
+                / self.unreachable_count as f32,
+            received_unreachable: self.unreachable_stats.get_tx_received_from_inbounds() as f32
+                / self.unreachable_count as f32,
+        }
+    }
+
+    pub fn avg_tx_outbounds(&self) -> AveragedStatistics {
+        AveragedStatistics {
+            sent_reachable: self.reachable_stats.get_tx_sent_to_outbounds() as f32
+                / self.reachable_count as f32,
+            received_reachable: self.reachable_stats.get_tx_received_from_outbounds() as f32
+                / self.reachable_count as f32,
+            sent_unreachable: self.unreachable_stats.get_tx_sent_to_outbounds() as f32
+                / self.unreachable_count as f32,
+            received_unreachable: self.unreachable_stats.get_tx_received_from_outbounds() as f32
                 / self.unreachable_count as f32,
         }
     }


### PR DESCRIPTION
The transaction size was assumed not to matter, as it was thought to be a constant term in the simulation. However, not accounting for it makes it hard to tell which nodes send transactions, given the added overhead when doing so boils down to a GETDATA message, which happens to have the same size as an INV. Therefore, distinguishing between a node sending two INVS or an INV+GETDATA+TX message is hard, when looking at the overall bandwidth numbers.

Changing this to make the transaction message sized. The size here doesn't matter too much, as long as it is within a reasonable transaction size (e.g. making it too small may make it too similar to INVs, while making it too big would be unrealistic).

Also, add statistics to account for transactions sent and received by different types of nodes (currently unused)