### PR TITLE
multi: Adds script for multi-runs

### DIFF
--- a/hyper-lib/Cargo.toml
+++ b/hyper-lib/Cargo.toml
@@ -14,6 +14,7 @@ graphrs = "0.9.0"
 hashbrown = "0.15"
 itertools = "0.13.0"
 log = "0.4.20"
+once_cell = "1.17"
 rand = "0.8.5"
 rand_distr = "0.4.3"
 serde = { version = "1.0", features = ["derive"] }

--- a/hyper-lib/src/lib.rs
+++ b/hyper-lib/src/lib.rs
@@ -65,6 +65,8 @@ pub struct OutputResult {
     reachable_count: usize,
     #[serde(rename = "u")]
     unreachable_count: usize,
+    out_fanout: usize,
+    in_fanout: f32,
     n: u32,
     erlay: bool,
     seed: u64,
@@ -98,6 +100,8 @@ impl OutputResult {
             unreachable_received_msgs: avg_msgs.received_unreachable() / n_float,
             unreachable_sent_bytes: avg_bytes.sent_unreachable() / n_float,
             unreachable_received_bytes: avg_bytes.received_unreachable() / n_float,
+            out_fanout: *crate::node::OUTBOUND_FANOUT_DESTINATIONS,
+            in_fanout: (*crate::node::INBOUND_FANOUT_DESTINATIONS_FRACTION) as f32,
             n: sim_params.n,
             reachable_count: sim_params.reachable,
             unreachable_count: sim_params.unreachable,

--- a/hyperion/multi-run.sh
+++ b/hyperion/multi-run.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# PARAMS
+$CALL_PARAMS = ""
+[[ -n "$1" ]] && CALL_PARAMS+="--outbounds $1 "
+[[ -n "$2" ]] && CALL_PARAMS+="--seed $2 "
+if [[ -n "$3" ]]; then CALL_PARAMS+="--out $3"
+elif [[ -n "$1" ]]; then CALL_PARAMS+="--out result_"$1".csv"
+else CALL_PARAMS+="--out result.csv"
+fi
+
+# ITER OPTIONS
+MAX_OUTBOUNDS=8
+MAX_INBOUNDS_FRACTION=1.0
+INBOUND_INCREMENT=0.1
+
+for ((OUTBOUND_FANOUT_DESTINATIONS = 0; OUTBOUND_FANOUT_DESTINATIONS < MAX_OUTBOUNDS; OUTBOUND_FANOUT_DESTINATIONS++))
+do
+    export OUTBOUND_FANOUT_DESTINATIONS
+    for INBOUND_FANOUT_DESTINATIONS_FRACTION in $(seq 0.0 $INBOUND_INCREMENT $MAX_INBOUNDS_FRACTION)
+    do
+        export INBOUND_FANOUT_DESTINATIONS_FRACTION
+        cargo run --release -- --erlay -n 100 $CALL_PARAMS
+    done
+done


### PR DESCRIPTION
Figuring out what are reasonable parameters for fanout peer selection is a combinatorics
problem, multiple configurations exist between inbounds and outbounds peers that need to be tested.
However, there is currently no easy way to run those using the simulator.

Allow `OUTBOUND_FANOUT_DESTINATIONS` and `INBOUND_FANOUT_DESTINATIONS_FRACTION` to be
defined from ENV variables and define a script for an easy way to run simulations
combining both