### PR TITLE
multi: Improves multi-run script

### DIFF
--- a/hyper-lib/src/lib.rs
+++ b/hyper-lib/src/lib.rs
@@ -65,6 +65,8 @@ pub struct OutputResult {
     reachable_count: usize,
     #[serde(rename = "u")]
     unreachable_count: usize,
+    in_poisson_mean: u16,
+    out_poisson_mean: u16,
     out_fanout: usize,
     in_fanout: f32,
     n: u32,
@@ -102,6 +104,8 @@ impl OutputResult {
             unreachable_received_bytes: avg_bytes.received_unreachable() / n_float,
             out_fanout: *crate::node::OUTBOUND_FANOUT_DESTINATIONS,
             in_fanout: (*crate::node::INBOUND_FANOUT_DESTINATIONS_FRACTION) as f32,
+            in_poisson_mean: *crate::node::INBOUND_INVENTORY_BROADCAST_INTERVAL as u16,
+            out_poisson_mean: *crate::node::OUTBOUND_INVENTORY_BROADCAST_INTERVAL as u16,
             n: sim_params.n,
             reachable_count: sim_params.reachable,
             unreachable_count: sim_params.unreachable,

--- a/hyper-lib/src/node.rs
+++ b/hyper-lib/src/node.rs
@@ -17,9 +17,19 @@ use crate::SECS_TO_NANOS;
 
 pub type NodeId = usize;
 
-static INBOUND_INVENTORY_BROADCAST_INTERVAL: u64 = 5;
-static OUTBOUND_INVENTORY_BROADCAST_INTERVAL: u64 = 2;
-static NONPREF_PEER_TX_DELAY: u64 = 2;
+pub(crate) static INBOUND_INVENTORY_BROADCAST_INTERVAL: Lazy<u64> = Lazy::new(|| {
+    env::var("INBOUND_INVENTORY_BROADCAST_INTERVAL")
+        .ok()
+        .and_then(|val| val.parse::<u64>().ok())
+        .unwrap_or(5)
+});
+pub(crate) static OUTBOUND_INVENTORY_BROADCAST_INTERVAL: Lazy<u64> = Lazy::new(|| {
+    env::var("OUTBOUND_INVENTORY_BROADCAST_INTERVAL")
+        .ok()
+        .and_then(|val| val.parse::<u64>().ok())
+        .unwrap_or(2)
+});
+
 pub(crate) static OUTBOUND_FANOUT_DESTINATIONS: Lazy<usize> = Lazy::new(|| {
     env::var("OUTBOUND_FANOUT_DESTINATIONS")
         .ok()
@@ -32,7 +42,9 @@ pub(crate) static INBOUND_FANOUT_DESTINATIONS_FRACTION: Lazy<f64> = Lazy::new(||
         .and_then(|val| val.parse::<f64>().ok())
         .unwrap_or(0.1)
 });
-pub static RECON_REQUEST_INTERVAL: u64 = 8;
+
+static NONPREF_PEER_TX_DELAY: u64 = 2;
+pub(crate) static RECON_REQUEST_INTERVAL: u64 = 8;
 
 macro_rules! debug_log {
     ($time:tt, $id:expr, $($arg:tt)*)
@@ -191,8 +203,8 @@ impl Node {
             requested_transaction: false,
             delayed_request: None,
             known_transaction: false,
-            inbounds_poisson_timer: PoissonTimer::new(INBOUND_INVENTORY_BROADCAST_INTERVAL),
-            outbounds_poisson_timer: PoissonTimer::new(OUTBOUND_INVENTORY_BROADCAST_INTERVAL),
+            inbounds_poisson_timer: PoissonTimer::new(*INBOUND_INVENTORY_BROADCAST_INTERVAL),
+            outbounds_poisson_timer: PoissonTimer::new(*OUTBOUND_INVENTORY_BROADCAST_INTERVAL),
             node_statistics: NodeStatistics::new(),
         }
     }

--- a/hyperion/multi-run.sh
+++ b/hyperion/multi-run.sh
@@ -1,15 +1,50 @@
 #!/bin/bash
 
-# PARAMS
-$CALL_PARAMS = ""
-[[ -n "$1" ]] && CALL_PARAMS+="--outbounds $1 "
-[[ -n "$2" ]] && CALL_PARAMS+="--seed $2 "
-if [[ -n "$3" ]]; then CALL_PARAMS+="--out $3"
-elif [[ -n "$1" ]]; then CALL_PARAMS+="--out result_"$1".csv"
-else CALL_PARAMS+="--out result.csv"
-fi
+# Help function
+usage() {
+    echo "Usage: $0 [-n <n>] [--out=<out>] [--outbounds=<outbounds>] [--seed=<seed>] [--ipm=<ipm>] [--opm=<opm>] [-h|--help]"
+    echo
+    echo "Options:"
+    echo "  -n                  Number of times the simulation will be repeated. Smooths the statistical results [default: 1]"
+    echo "  --out               output file name (default: result.csv)"
+    echo "  --outbounds         Number of outbound connections per node [default: 8]"
+    echo "  --seed              RNG seed for reproducible results. Randomly generated if not provided"
+    echo "  --ipm               Inbounds Poisson timer mean value [default: 5]"
+    echo "  --opm               Outbounds Poisson timer mean value [default: 2]"
+    echo "  -h | --help         Show this help message and exit"
+    exit 1
+}
 
-# ITER OPTIONS
+CALL_PARAMS=""
+OUTPUT_FILE="result.csv"
+N=100
+
+# Parse arguments
+for arg in "$@"; do
+    case $arg in
+        -n=*)
+            N="${arg#*=}" ;;
+        --out=*)
+            OUTPUT_FILE="${arg#*=}" ;;
+        --outbounds=*)
+            CALL_PARAMS+="--outbounds ${arg#*=} " ;;
+        --seed=*)
+            CALL_PARAMS+="--seed ${arg#*=} " ;;
+        --ipm=*)
+            INBOUND_INVENTORY_BROADCAST_INTERVAL="${arg#*=}"
+            export INBOUND_INVENTORY_BROADCAST_INTERVAL ;;
+        --opm=*)
+            OUTBOUND_INVENTORY_BROADCAST_INTERVAL="${arg#*=}"
+            export OUTBOUND_INVENTORY_BROADCAST_INTERVAL ;;
+        -h |--help)
+            usage ;;
+    *)
+      echo "Unknown option: $arg"
+      usage ;;
+  esac
+done
+
+# Iter options
 MAX_OUTBOUNDS=8
 MAX_INBOUNDS_FRACTION=1.0
 INBOUND_INCREMENT=0.1
@@ -20,6 +55,6 @@ do
     for INBOUND_FANOUT_DESTINATIONS_FRACTION in $(seq 0.0 $INBOUND_INCREMENT $MAX_INBOUNDS_FRACTION)
     do
         export INBOUND_FANOUT_DESTINATIONS_FRACTION
-        cargo run --release -- --erlay -n 100 $CALL_PARAMS
+        cargo run --release -- --erlay -n $N --out $OUTPUT_FILE $CALL_PARAMS
     done
 done


### PR DESCRIPTION
Adds the options to modify `{INBOUND, OUTBOUND}_INVENTORY_BROADCAST_INTERVAL` from env variables so the multi-run script can be run without needing to re-compile.

Also, improves the script itself to be more user-friendly