### PR TITLE
lib: Makes simulations 100% reproducible

### DIFF
--- a/hyper-lib/Cargo.toml
+++ b/hyper-lib/Cargo.toml
@@ -11,7 +11,6 @@ Supporting library for hyperion: a discrete time network event simulator for Bit
 [dependencies]
 # FIXME: Move this into a feature
 graphrs = "0.9.0"
-hashbrown = "0.15"
 itertools = "0.13.0"
 log = "0.4.20"
 once_cell = "1.17"

--- a/hyper-lib/src/indexedmap.rs
+++ b/hyper-lib/src/indexedmap.rs
@@ -1,10 +1,10 @@
-use hashbrown::hash_map::Keys;
-use hashbrown::HashMap;
+use std::collections::btree_map::Keys;
+use std::collections::BTreeMap;
 use std::hash::Hash;
 
 #[derive(Clone)]
 pub struct IndexedMap<K, V> {
-    map: HashMap<K, V>,
+    map: BTreeMap<K, V>,
     // Consider storing references. I didn't do it because that means carrying the lifetime
     // over all the objects including this map
     // If we are on with adding lifetimes, making this a Cycle iterator may also be an option
@@ -14,21 +14,21 @@ pub struct IndexedMap<K, V> {
 
 impl<K, V> IndexedMap<K, V>
 where
-    K: Hash + Eq + Copy,
+    K: Hash + Eq + Copy + Ord,
 {
     pub fn new() -> Self {
         Self {
-            map: HashMap::new(),
+            map: BTreeMap::new(),
             order: Vec::new(),
             next_index: 0,
         }
     }
 
-    pub fn inner(&self) -> &HashMap<K, V> {
+    pub fn inner(&self) -> &BTreeMap<K, V> {
         &self.map
     }
 
-    pub fn inner_mut(&mut self) -> &mut HashMap<K, V> {
+    pub fn inner_mut(&mut self) -> &mut BTreeMap<K, V> {
         &mut self.map
     }
 

--- a/hyper-lib/src/network.rs
+++ b/hyper-lib/src/network.rs
@@ -6,9 +6,9 @@ use crate::SECS_TO_NANOS;
 use std::cell::RefCell;
 use std::rc::Rc;
 
-use hashbrown::{HashMap, HashSet};
 use rand::rngs::StdRng;
 use rand_distr::{Distribution, LogNormal, Uniform};
+use std::collections::{HashMap, HashSet};
 
 static NET_LATENCY_MEAN: f64 = 0.01 * SECS_TO_NANOS as f64; // 10ms
 

--- a/hyper-lib/src/node.rs
+++ b/hyper-lib/src/node.rs
@@ -1,8 +1,8 @@
 use std::cell::RefCell;
+use std::collections::BTreeMap;
 use std::env;
 use std::rc::Rc;
 
-use hashbrown::HashMap;
 use once_cell::sync::Lazy;
 use rand::prelude::IteratorRandom;
 use rand::rngs::StdRng;
@@ -169,7 +169,7 @@ pub struct Node {
     /// Whether the node supports Erlay or not
     is_erlay: bool,
     /// Map of inbound peers identified by their (global) node identifier
-    in_peers: HashMap<NodeId, Peer>,
+    in_peers: BTreeMap<NodeId, Peer>,
     /// Map of outbound peers identified by their (global) node identifier
     out_peers: IndexedMap<NodeId, Peer>,
     /// Whether the transaction has been requested (but not yet received)
@@ -198,7 +198,7 @@ impl Node {
             rng,
             is_reachable,
             is_erlay,
-            in_peers: HashMap::new(),
+            in_peers: BTreeMap::new(),
             out_peers: IndexedMap::new(),
             requested_transaction: false,
             delayed_request: None,
@@ -263,19 +263,19 @@ impl Node {
         self.node_id
     }
 
-    pub fn get_inbounds(&self) -> &HashMap<NodeId, Peer> {
+    pub fn get_inbounds(&self) -> &BTreeMap<NodeId, Peer> {
         &self.in_peers
     }
 
-    pub fn get_inbounds_mut(&mut self) -> &mut HashMap<NodeId, Peer> {
+    pub fn get_inbounds_mut(&mut self) -> &mut BTreeMap<NodeId, Peer> {
         &mut self.in_peers
     }
 
-    pub fn get_outbounds(&self) -> &HashMap<NodeId, Peer> {
+    pub fn get_outbounds(&self) -> &BTreeMap<NodeId, Peer> {
         self.out_peers.inner()
     }
 
-    pub fn get_outbounds_mut(&mut self) -> &mut HashMap<NodeId, Peer> {
+    pub fn get_outbounds_mut(&mut self) -> &mut BTreeMap<NodeId, Peer> {
         self.out_peers.inner_mut()
     }
 


### PR DESCRIPTION
This fixes the last bits of non-reproducibility in the simulator. The only missing part was related to how peers were iterated when random ones needed to be picked. Creating iterating over a hashmap would build an iterator whose order depends on the hashmap random state. However, we were not in control con how that random state is seeded. Replacing HashMaps with BTreeMaps yields iterators that preserve the order, which gets rid of the unexpected randomness.

Gets rid of Hashbrown since we are not using HashMaps that heavily anymore.